### PR TITLE
Use lazy initialization in getSupportedTypeQualifiers()

### DIFF
--- a/checker/src/org/checkerframework/checker/fenum/FenumAnnotatedTypeFactory.java
+++ b/checker/src/org/checkerframework/checker/fenum/FenumAnnotatedTypeFactory.java
@@ -72,7 +72,7 @@ public class FenumAnnotatedTypeFactory extends BaseAnnotatedTypeFactory {
 
         // TODO: warn if no qualifiers given?
         // Just Fenum("..") is still valid, though...
-        return Collections.unmodifiableSet(qualSet);
+        return qualSet;
     }
 
     @Override

--- a/checker/src/org/checkerframework/checker/i18n/I18nAnnotatedTypeFactory.java
+++ b/checker/src/org/checkerframework/checker/i18n/I18nAnnotatedTypeFactory.java
@@ -31,9 +31,8 @@ public class I18nAnnotatedTypeFactory extends BaseAnnotatedTypeFactory {
 
     @Override
     protected Set<Class<? extends Annotation>> createSupportedTypeQualifiers() {
-        return Collections.unmodifiableSet(
-                new LinkedHashSet<Class<? extends Annotation>>(
-                        Arrays.asList(Localized.class, UnknownLocalized.class)));
+        return new LinkedHashSet<Class<? extends Annotation>>(
+                        Arrays.asList(Localized.class, UnknownLocalized.class));
     }
 
     @Override

--- a/checker/src/org/checkerframework/checker/i18n/LocalizableKeyAnnotatedTypeFactory.java
+++ b/checker/src/org/checkerframework/checker/i18n/LocalizableKeyAnnotatedTypeFactory.java
@@ -33,9 +33,8 @@ public class LocalizableKeyAnnotatedTypeFactory extends
 
     @Override
     protected Set<Class<? extends Annotation>> createSupportedTypeQualifiers() {
-        return Collections.unmodifiableSet(
-                new LinkedHashSet<Class<? extends Annotation>>(
-                        Arrays.asList(LocalizableKey.class, PropertyKey.class, PropertyKeyBottom.class, UnknownPropertyKey.class)));
+        return new LinkedHashSet<Class<? extends Annotation>>(
+                        Arrays.asList(LocalizableKey.class, PropertyKey.class, PropertyKeyBottom.class, UnknownPropertyKey.class));
     }
 
     @Override

--- a/checker/src/org/checkerframework/checker/lock/LockAnnotatedTypeFactory.java
+++ b/checker/src/org/checkerframework/checker/lock/LockAnnotatedTypeFactory.java
@@ -102,11 +102,10 @@ public class LockAnnotatedTypeFactory
 
     @Override
     protected Set<Class<? extends Annotation>> createSupportedTypeQualifiers() {
-        return Collections.unmodifiableSet(
-                new LinkedHashSet<Class<? extends Annotation>>(
+        return new LinkedHashSet<Class<? extends Annotation>>(
                         Arrays.asList(LockHeld.class, LockPossiblyHeld.class,
                                 GuardedBy.class, GuardedByUnknown.class,
-                                GuardSatisfied.class, GuardedByBottom.class)));
+                                GuardSatisfied.class, GuardedByBottom.class));
     }
 
     @Override

--- a/checker/src/org/checkerframework/checker/nullness/KeyForAnnotatedTypeFactory.java
+++ b/checker/src/org/checkerframework/checker/nullness/KeyForAnnotatedTypeFactory.java
@@ -118,10 +118,9 @@ public class KeyForAnnotatedTypeFactory extends
 
     @Override
     protected Set<Class<? extends Annotation>> createSupportedTypeQualifiers() {
-        return Collections.unmodifiableSet(
-                new LinkedHashSet<Class<? extends Annotation>>(
+        return new LinkedHashSet<Class<? extends Annotation>>(
                         Arrays.asList(KeyFor.class, UnknownKeyFor.class, KeyForBottom.class,
-                                PolyKeyFor.class, PolyAll.class)));
+                                PolyKeyFor.class, PolyAll.class));
     }
 
     @Override

--- a/checker/src/org/checkerframework/checker/nullness/NullnessAnnotatedTypeFactory.java
+++ b/checker/src/org/checkerframework/checker/nullness/NullnessAnnotatedTypeFactory.java
@@ -173,18 +173,16 @@ public class NullnessAnnotatedTypeFactory
         AbstractNullnessChecker ckr = (AbstractNullnessChecker) checker;
         // if useFbc is true, then it is the NullnessChecker
         if (ckr.useFbc) {
-            return Collections.unmodifiableSet(
-                    new LinkedHashSet<Class<? extends Annotation>>(
+            return new LinkedHashSet<Class<? extends Annotation>>(
                             Arrays.asList(Nullable.class, MonotonicNonNull.class, NonNull.class, UnderInitialization.class,
-                                    Initialized.class, UnknownInitialization.class, FBCBottom.class, PolyNull.class, PolyAll.class)));
+                                    Initialized.class, UnknownInitialization.class, FBCBottom.class, PolyNull.class, PolyAll.class));
         }
         // otherwise, it is the NullnessRawnessChecker
         else {
-            return Collections.unmodifiableSet(
-                    new LinkedHashSet<Class<? extends Annotation>>(
+            return new LinkedHashSet<Class<? extends Annotation>>(
                             Arrays.asList(Nullable.class, MonotonicNonNull.class, NonNull.class, NonRaw.class, Raw.class,
                                     // PolyRaw.class, //TODO: support PolyRaw in the future
-                                    PolyNull.class, PolyAll.class)));
+                                    PolyNull.class, PolyAll.class));
         }
     }
 

--- a/checker/src/org/checkerframework/checker/units/UnitsAnnotatedTypeFactory.java
+++ b/checker/src/org/checkerframework/checker/units/UnitsAnnotatedTypeFactory.java
@@ -157,7 +157,7 @@ public class UnitsAnnotatedTypeFactory extends BaseAnnotatedTypeFactory {
         // copy all loaded external Units to qual set
         qualSet.addAll(externalQualsMap.values());
 
-        return Collections.unmodifiableSet(qualSet);
+        return qualSet;
     }
 
     private void loadAllExternalUnits() {

--- a/framework/src/org/checkerframework/common/reflection/ClassValAnnotatedTypeFactory.java
+++ b/framework/src/org/checkerframework/common/reflection/ClassValAnnotatedTypeFactory.java
@@ -60,9 +60,8 @@ public class ClassValAnnotatedTypeFactory extends BaseAnnotatedTypeFactory {
 
     @Override
     protected Set<Class<? extends Annotation>> createSupportedTypeQualifiers() {
-        return Collections.unmodifiableSet(
-                new HashSet<Class<? extends Annotation>>(
-                        Arrays.asList(UnknownClass.class, ClassVal.class, ClassBound.class, ClassValBottom.class)));
+        return new HashSet<Class<? extends Annotation>>(
+                        Arrays.asList(UnknownClass.class, ClassVal.class, ClassBound.class, ClassValBottom.class));
     }
 
     private AnnotationMirror createClassVal(List<String> values) {

--- a/framework/src/org/checkerframework/common/reflection/MethodValAnnotatedTypeFactory.java
+++ b/framework/src/org/checkerframework/common/reflection/MethodValAnnotatedTypeFactory.java
@@ -55,9 +55,8 @@ public class MethodValAnnotatedTypeFactory extends BaseAnnotatedTypeFactory {
 
     @Override
     protected Set<Class<? extends Annotation>> createSupportedTypeQualifiers() {
-        return Collections.unmodifiableSet(
-                new HashSet<Class<? extends Annotation>>(
-                        Arrays.asList(MethodVal.class, MethodValBottom.class, UnknownMethod.class)));
+        return new HashSet<Class<? extends Annotation>>(
+                        Arrays.asList(MethodVal.class, MethodValBottom.class, UnknownMethod.class));
     }
 
     @Override

--- a/framework/src/org/checkerframework/common/subtyping/SubtypingAnnotatedTypeFactory.java
+++ b/framework/src/org/checkerframework/common/subtyping/SubtypingAnnotatedTypeFactory.java
@@ -58,6 +58,6 @@ public class SubtypingAnnotatedTypeFactory extends BaseAnnotatedTypeFactory {
             }
         }
 
-        return Collections.unmodifiableSet(qualSet);
+        return qualSet;
     }
 }

--- a/framework/src/org/checkerframework/framework/type/AnnotatedTypeFactory.java
+++ b/framework/src/org/checkerframework/framework/type/AnnotatedTypeFactory.java
@@ -655,9 +655,9 @@ public class AnnotatedTypeFactory implements AnnotationProvider {
     }
 
     /**
-     * Returns an immutable set of annotation classes that are supported by a checker
+     * Returns a mutable set of annotation classes that are supported by a checker
      * <p>
-     * Subclasses may override this method and to return an immutable set
+     * Subclasses may override this method and to return an mutable set
      * of their supported type qualifiers through one of the 5 approaches shown below.
      * <p>
      * Subclasses should not call this method; they should call
@@ -736,22 +736,21 @@ public class AnnotatedTypeFactory implements AnnotationProvider {
      * <li>
      * Supporting only annotations that are explicitly listed:
      * Override
-     * {@link #createSupportedTypeQualifiers()} and return an immutable
+     * {@link #createSupportedTypeQualifiers()} and return an mutable
      * set of the supported annotations. Code example:
      * <pre>
      * {@code @Override protected Set<Class<? extends Annotation>> createSupportedTypeQualifiers() {
-     *      return Collections.unmodifiableSet(
-     *          new HashSet<Class<? extends Annotation>>(
-     *              Arrays.asList(A.class, B.class)));
+     *      return new HashSet<Class<? extends Annotation>>(
+     *              Arrays.asList(A.class, B.class));
      *  } }
      * </pre>
      *
      * The set of qualifiers returned by
-     * {@link #createSupportedTypeQualifiers()} must be an immutable
+     * {@link #createSupportedTypeQualifiers()} could be mutable
      * set. The methods
      * {@link #getBundledTypeQualifiersWithoutPolyAll(Class...)} and
      * {@link #getBundledTypeQualifiersWithPolyAll(Class...)} each
-     * return an immutable set.
+     * could return an mutable set.
      * </li>
      * </ol>
      *
@@ -775,14 +774,14 @@ public class AnnotatedTypeFactory implements AnnotationProvider {
      *            a varargs array of explicitly listed annotation classes to be
      *            added to the returned set. For example, it is used frequently
      *            to add Bottom qualifiers.
-     * @return an immutable set of the loaded and listed annotation classes, as
+     * @return an mutable set of the loaded and listed annotation classes, as
      *         well as {@link PolyAll}.
      */
     @SafeVarargs
     protected final Set<Class<? extends Annotation>> getBundledTypeQualifiersWithPolyAll(Class<? extends Annotation>... explicitlyListedAnnotations) {
         Set<Class<? extends Annotation>> annotations = loadTypeAnnotationsFromQualDir(explicitlyListedAnnotations);
         annotations.add(PolyAll.class);
-        return Collections.unmodifiableSet(annotations);
+        return annotations;
     }
 
     /**
@@ -797,11 +796,11 @@ public class AnnotatedTypeFactory implements AnnotationProvider {
      *            a varargs array of explicitly listed annotation classes to be
      *            added to the returned set. For example, it is used frequently
      *            to add Bottom qualifiers.
-     * @return an immutable set of the loaded, and listed annotation classes
+     * @return an mutable set of the loaded, and listed annotation classes
      */
     @SafeVarargs
     protected final Set<Class<? extends Annotation>> getBundledTypeQualifiersWithoutPolyAll(Class<? extends Annotation>... explicitlyListedAnnotations) {
-        return Collections.unmodifiableSet(loadTypeAnnotationsFromQualDir(explicitlyListedAnnotations));
+        return loadTypeAnnotationsFromQualDir(explicitlyListedAnnotations);
     }
 
     /**

--- a/framework/src/org/checkerframework/framework/type/AnnotatedTypeFactory.java
+++ b/framework/src/org/checkerframework/framework/type/AnnotatedTypeFactory.java
@@ -746,11 +746,11 @@ public class AnnotatedTypeFactory implements AnnotationProvider {
      * </pre>
      *
      * The set of qualifiers returned by
-     * {@link #createSupportedTypeQualifiers()} could be mutable
+     * {@link #createSupportedTypeQualifiers()} must be a fresh, mutable
      * set. The methods
      * {@link #getBundledTypeQualifiersWithoutPolyAll(Class...)} and
      * {@link #getBundledTypeQualifiersWithPolyAll(Class...)} each
-     * could return a mutable set.
+     * must return a fresh, mutable set
      * </li>
      * </ol>
      *

--- a/framework/src/org/checkerframework/framework/type/AnnotatedTypeFactory.java
+++ b/framework/src/org/checkerframework/framework/type/AnnotatedTypeFactory.java
@@ -337,8 +337,7 @@ public class AnnotatedTypeFactory implements AnnotationProvider {
         this.visitorState = new VisitorState();
 
         this.loader = new AnnotationClassLoader(checker);
-        this.supportedQuals = createSupportedTypeQualifiers();
-        checkSupportedQuals();
+        this.supportedQuals = new HashSet<>();
 
         this.fromByteCode = AnnotationUtils.fromClass(elements, FromByteCode.class);
         this.fromStubFile = AnnotationUtils.fromClass(elements, FromStubFile.class);
@@ -358,6 +357,7 @@ public class AnnotatedTypeFactory implements AnnotationProvider {
             this.elementCache = null;
             this.elementToTreeCache = null;
         }
+
         this.typeFormatter = createAnnotatedTypeFormatter();
         this.annotationFormatter = createAnnotationFormatter();
 
@@ -869,7 +869,11 @@ public class AnnotatedTypeFactory implements AnnotationProvider {
      *         empty set if no qualifiers are supported
      */
     public final Set<Class<? extends Annotation>> getSupportedTypeQualifiers() {
-        return supportedQuals;
+        if (this.supportedQuals.isEmpty()) {
+            supportedQuals.addAll(createSupportedTypeQualifiers());
+            checkSupportedQuals();
+        }
+        return Collections.unmodifiableSet(supportedQuals);
     }
 
     // **********************************************************************

--- a/framework/src/org/checkerframework/framework/type/AnnotatedTypeFactory.java
+++ b/framework/src/org/checkerframework/framework/type/AnnotatedTypeFactory.java
@@ -657,7 +657,7 @@ public class AnnotatedTypeFactory implements AnnotationProvider {
     /**
      * Returns a mutable set of annotation classes that are supported by a checker
      * <p>
-     * Subclasses may override this method and to return an mutable set
+     * Subclasses may override this method and to return a mutable set
      * of their supported type qualifiers through one of the 5 approaches shown below.
      * <p>
      * Subclasses should not call this method; they should call
@@ -736,7 +736,7 @@ public class AnnotatedTypeFactory implements AnnotationProvider {
      * <li>
      * Supporting only annotations that are explicitly listed:
      * Override
-     * {@link #createSupportedTypeQualifiers()} and return an mutable
+     * {@link #createSupportedTypeQualifiers()} and return a mutable
      * set of the supported annotations. Code example:
      * <pre>
      * {@code @Override protected Set<Class<? extends Annotation>> createSupportedTypeQualifiers() {
@@ -750,7 +750,7 @@ public class AnnotatedTypeFactory implements AnnotationProvider {
      * set. The methods
      * {@link #getBundledTypeQualifiersWithoutPolyAll(Class...)} and
      * {@link #getBundledTypeQualifiersWithPolyAll(Class...)} each
-     * could return an mutable set.
+     * could return a mutable set.
      * </li>
      * </ol>
      *
@@ -774,7 +774,7 @@ public class AnnotatedTypeFactory implements AnnotationProvider {
      *            a varargs array of explicitly listed annotation classes to be
      *            added to the returned set. For example, it is used frequently
      *            to add Bottom qualifiers.
-     * @return an mutable set of the loaded and listed annotation classes, as
+     * @return a mutable set of the loaded and listed annotation classes, as
      *         well as {@link PolyAll}.
      */
     @SafeVarargs
@@ -796,7 +796,7 @@ public class AnnotatedTypeFactory implements AnnotationProvider {
      *            a varargs array of explicitly listed annotation classes to be
      *            added to the returned set. For example, it is used frequently
      *            to add Bottom qualifiers.
-     * @return an mutable set of the loaded, and listed annotation classes
+     * @return a mutable set of the loaded, and listed annotation classes
      */
     @SafeVarargs
     protected final Set<Class<? extends Annotation>> getBundledTypeQualifiersWithoutPolyAll(Class<? extends Annotation>... explicitlyListedAnnotations) {

--- a/framework/src/org/checkerframework/framework/util/PurityAnnotatedTypeFactory.java
+++ b/framework/src/org/checkerframework/framework/util/PurityAnnotatedTypeFactory.java
@@ -17,8 +17,7 @@ public class PurityAnnotatedTypeFactory extends BaseAnnotatedTypeFactory {
 
     @Override
     protected Set<Class<? extends Annotation>> createSupportedTypeQualifiers() {
-        return Collections.unmodifiableSet(
-                new HashSet<Class<? extends Annotation>>(
-                        Arrays.asList(PurityUnqualified.class)));
+        return new HashSet<Class<? extends Annotation>>(
+                        Arrays.asList(PurityUnqualified.class));
     }
 }

--- a/framework/src/org/checkerframework/qualframework/base/QualifiedTypeFactoryAdapter.java
+++ b/framework/src/org/checkerframework/qualframework/base/QualifiedTypeFactoryAdapter.java
@@ -18,6 +18,7 @@ import org.checkerframework.qualframework.base.dataflow.QualTransferAdapter;
 
 import java.lang.annotation.Annotation;
 import java.util.Collections;
+import java.util.HashSet;
 import java.util.List;
 import java.util.Set;
 
@@ -61,7 +62,7 @@ class QualifiedTypeFactoryAdapter<Q> extends BaseAnnotatedTypeFactory {
     // and process them in a classical manner
     @Override
     protected Set<Class<? extends Annotation>> createSupportedTypeQualifiers() {
-        return Collections.emptySet();
+        return new HashSet<>();
     }
 
     @Override

--- a/framework/tests/src/tests/compound/AnotherCompoundCheckerAnnotatedTypeFactory.java
+++ b/framework/tests/src/tests/compound/AnotherCompoundCheckerAnnotatedTypeFactory.java
@@ -30,9 +30,8 @@ public class AnotherCompoundCheckerAnnotatedTypeFactory extends
 
     @Override
     protected Set<Class<? extends Annotation>> createSupportedTypeQualifiers() {
-        return Collections.unmodifiableSet(
-                new HashSet<Class<? extends Annotation>>(
-                        Arrays.asList(ACCTop.class, ACCBottom.class)));
+        return new HashSet<Class<? extends Annotation>>(
+                        Arrays.asList(ACCTop.class, ACCBottom.class));
     }
 
     @Override

--- a/framework/tests/src/tests/compound/CompoundCheckerAnnotatedTypeFactory.java
+++ b/framework/tests/src/tests/compound/CompoundCheckerAnnotatedTypeFactory.java
@@ -30,9 +30,8 @@ public class CompoundCheckerAnnotatedTypeFactory extends
 
     @Override
     protected Set<Class<? extends Annotation>> createSupportedTypeQualifiers() {
-        return Collections.unmodifiableSet(
-                new HashSet<Class<? extends Annotation>>(
-                        Arrays.asList(CCTop.class, CCBottom.class)));
+        return new HashSet<Class<? extends Annotation>>(
+                        Arrays.asList(CCTop.class, CCBottom.class));
     }
 
     @Override

--- a/framework/tests/src/tests/defaulting/DefaultingLowerBoundAnnotatedTypeFactory.java
+++ b/framework/tests/src/tests/defaulting/DefaultingLowerBoundAnnotatedTypeFactory.java
@@ -23,8 +23,7 @@ public class DefaultingLowerBoundAnnotatedTypeFactory extends BaseAnnotatedTypeF
 
     @Override
     protected Set<Class<? extends Annotation>> createSupportedTypeQualifiers() {
-        return Collections.unmodifiableSet(
-                new HashSet<Class<? extends Annotation>>(
-                        Arrays.asList(LB_TOP.class, LB_EXPLICIT.class, LB_IMPLICIT.class, LB_BOTTOM.class)));
+        return new HashSet<Class<? extends Annotation>>(
+                        Arrays.asList(LB_TOP.class, LB_EXPLICIT.class, LB_IMPLICIT.class, LB_BOTTOM.class));
     }
 }

--- a/framework/tests/src/tests/defaulting/DefaultingUpperBoundAnnotatedTypeFactory.java
+++ b/framework/tests/src/tests/defaulting/DefaultingUpperBoundAnnotatedTypeFactory.java
@@ -23,8 +23,7 @@ public class DefaultingUpperBoundAnnotatedTypeFactory extends BaseAnnotatedTypeF
 
     @Override
     protected Set<Class<? extends Annotation>> createSupportedTypeQualifiers() {
-        return Collections.unmodifiableSet(
-                new HashSet<Class<? extends Annotation>>(
-                        Arrays.asList(UB_TOP.class, UB_EXPLICIT.class, UB_IMPLICIT.class, UB_BOTTOM.class)));
+        return new HashSet<Class<? extends Annotation>>(
+                        Arrays.asList(UB_TOP.class, UB_EXPLICIT.class, UB_IMPLICIT.class, UB_BOTTOM.class));
     }
 }

--- a/framework/tests/src/tests/supportedquals/SupportedQualsChecker.java
+++ b/framework/tests/src/tests/supportedquals/SupportedQualsChecker.java
@@ -37,9 +37,8 @@ public class SupportedQualsChecker extends BaseTypeChecker {
         }
         @Override
         protected Set<Class<? extends Annotation>> createSupportedTypeQualifiers() {
-            return Collections.unmodifiableSet(
-                    new HashSet<Class<? extends Annotation>>(Arrays.asList(Qualifier.class,
-                            BottomQualifier.class)));
+            return new HashSet<Class<? extends Annotation>>(Arrays.asList(Qualifier.class,
+                            BottomQualifier.class));
         }
     }
 }

--- a/framework/tests/src/tests/util/FlowTestAnnotatedTypeFactory.java
+++ b/framework/tests/src/tests/util/FlowTestAnnotatedTypeFactory.java
@@ -38,9 +38,8 @@ public class FlowTestAnnotatedTypeFactory extends BaseAnnotatedTypeFactory {
 
     @Override
     protected Set<Class<? extends Annotation>> createSupportedTypeQualifiers() {
-        return Collections.unmodifiableSet(
-                new HashSet<Class<? extends Annotation>>(
-                        Arrays.asList(Value.class, Odd.class, MonotonicOdd.class, Unqualified.class, Bottom.class)));
+        return new HashSet<Class<? extends Annotation>>(
+                        Arrays.asList(Value.class, Odd.class, MonotonicOdd.class, Unqualified.class, Bottom.class));
     }
 
     @Override

--- a/framework/tests/src/tests/util/TestChecker.java
+++ b/framework/tests/src/tests/util/TestChecker.java
@@ -78,9 +78,8 @@ class TestAnnotatedTypeFactory extends BaseAnnotatedTypeFactory {
 
     @Override
     protected Set<Class<? extends Annotation>> createSupportedTypeQualifiers() {
-        return Collections.unmodifiableSet(
-                new HashSet<Class<? extends Annotation>>(
-                        Arrays.asList(Odd.class, MonotonicOdd.class, Even.class, Unqualified.class, Bottom.class)));
+        return new HashSet<Class<? extends Annotation>>(
+                        Arrays.asList(Odd.class, MonotonicOdd.class, Even.class, Unqualified.class, Bottom.class));
     }
 
     @Override

--- a/framework/tests/src/tests/wholeprograminference/WholeProgramInferenceTestAnnotatedTypeFactory.java
+++ b/framework/tests/src/tests/wholeprograminference/WholeProgramInferenceTestAnnotatedTypeFactory.java
@@ -55,11 +55,10 @@ public class WholeProgramInferenceTestAnnotatedTypeFactory extends BaseAnnotated
 
     @Override
     protected Set<Class<? extends Annotation>> createSupportedTypeQualifiers() {
-        return Collections.unmodifiableSet(
-                new HashSet<Class<? extends Annotation>>(Arrays.asList(
+        return new HashSet<Class<? extends Annotation>>(Arrays.asList(
                     Parent.class, DefaultType.class, Top.class, Sibling1.class,
                     Sibling2.class, WholeProgramInferenceBottom.class,
-                    SiblingWithFields.class, ImplicitAnno.class)));
+                    SiblingWithFields.class, ImplicitAnno.class));
     }
     @Override
     public TreeAnnotator createTreeAnnotator() {

--- a/framework/tests/test-lubglb/lubglb/LubGlbAnnotatedTypeFactory.java
+++ b/framework/tests/test-lubglb/lubglb/LubGlbAnnotatedTypeFactory.java
@@ -25,9 +25,8 @@ public class LubGlbAnnotatedTypeFactory extends BaseAnnotatedTypeFactory {
 
     @Override
     protected Set<Class<? extends Annotation>> createSupportedTypeQualifiers() {
-        return Collections.unmodifiableSet(
-                new HashSet<Class<? extends Annotation>>(
-                        Arrays.asList(A.class, B.class, C.class, D.class, E.class, F.class)));
+        return new HashSet<Class<? extends Annotation>>(
+                        Arrays.asList(A.class, B.class, C.class, D.class, E.class, F.class));
     }
 
 }


### PR DESCRIPTION
`AnnotatedTypeFactory#createSupportedTypeQualifiers()` is an overridable method, and should avoid using it in constructor.

Currently using it in constructor would cause NullPointer Exception in `InferenceAnnotatedTypeFactory#createSupportedTypeQualifiers()` if `InferenceAnnotatedTypeFactory` doesn't use the deprecated method `InferenceMain#getRealTypeFactory()`.

A better way of creating supported type qualifiers would be using laze initialisation, i.e. we create an empty set during constructor, and creating the supported qualifiers when `AnnotatedTypeFactory#getSupportedTypeQualifiers()` get called.