### PR TITLE
Fix Nullpointer Exception in DOTCFGVisualizer#visualizeBlockNode() when analysis is null

### DIFF
--- a/dataflow/src/org/checkerframework/dataflow/cfg/DOTCFGVisualizer.java
+++ b/dataflow/src/org/checkerframework/dataflow/cfg/DOTCFGVisualizer.java
@@ -186,7 +186,8 @@ public class DOTCFGVisualizer<A extends AbstractValue<A>,
         return this.sbDigraph.toString();
     }
 
-    protected void generateDotNodes(Set<Block> visited, ControlFlowGraph cfg, Analysis<A, S, T> analysis) {
+    protected void generateDotNodes(Set<Block> visited, ControlFlowGraph cfg,
+            /*@Nullable*/ Analysis<A, S, T> analysis) {
         IdentityHashMap<Block, List<Integer>> processOrder = getProcessOrder(cfg);
         this.sbDigraph.append("    node [shape=rectangle];\n\n");
         // definition of all nodes including their labels
@@ -347,6 +348,8 @@ public class DOTCFGVisualizer<A extends AbstractValue<A>,
 
     @Override
     public void visualizeBlockTransferInput(Block bb, Analysis<A, S, T> analysis) {
+        assert analysis != null : "analysis should be non-null when visualize transfer input of a block";
+
         TransferInput<A, S> input = analysis.getInput(bb);
         this.sbStore.setLength(0);
 
@@ -397,12 +400,11 @@ public class DOTCFGVisualizer<A extends AbstractValue<A>,
 
     @Override
     public void visualizeBlockNode(Node t, /*@Nullable*/ Analysis<A, S, T> analysis) {
-        A value = analysis.getValue(t);
-        String valueInfo = "";
-        if (value != null) {
-            valueInfo = "    > " + prepareString(value.toString());
+        this.sbBlock.append(prepareString(t.toString()) + "   [ " + prepareNodeType(t) + " ]");
+        A value = null;
+        if (analysis != null && (value = analysis.getValue(t)) != null) {
+            this.sbBlock.append("    > " + prepareString(value.toString()));
         }
-        this.sbBlock.append(prepareString(t.toString()) + "   [ " + prepareNodeType(t) + " ]" + valueInfo);
     }
 
     protected String prepareNodeType(Node t) {

--- a/dataflow/src/org/checkerframework/dataflow/cfg/DOTCFGVisualizer.java
+++ b/dataflow/src/org/checkerframework/dataflow/cfg/DOTCFGVisualizer.java
@@ -402,8 +402,11 @@ public class DOTCFGVisualizer<A extends AbstractValue<A>,
     public void visualizeBlockNode(Node t, /*@Nullable*/ Analysis<A, S, T> analysis) {
         this.sbBlock.append(prepareString(t.toString()) + "   [ " + prepareNodeType(t) + " ]");
         A value = null;
-        if (analysis != null && (value = analysis.getValue(t)) != null) {
-            this.sbBlock.append("    > " + prepareString(value.toString()));
+        if (analysis != null) {
+            value = analysis.getValue(t);
+            if (value != null) {
+                this.sbBlock.append("    > " + prepareString(value.toString()));
+            }
         }
     }
 


### PR DESCRIPTION
The `DOTCFGVisualizer` should also visualise a Control Flow Graph without analysis.

However, the `DOTCFGVisualizer#visualizeBlockNode()` method will throw a null pointer exception when `analysis` is null, because it will always try to visualize the `abstractValue` of a `node` even if there actually no `analysis` is provided.

I changed this method to first append `node` to the `sbBlock`, and then only append `asbtractValue` from `analysis` if the `analysis` is non-null.

In this PR I also make other two small related changes:

1. add /*@Nullable*/ annotation on the parameter `analysis` of method `generateDotNodes()`, because this method also should accept a nullable `analysis`.

2. add assertion that "`analysis` is non-null" in method `visualizeBlockTransferInput()`, because this method should only be called when `analysis` is non-null.

