### PR TITLE
enable storing extends/implements in TypesIntoElements#store()

### DIFF
--- a/framework/src/org/checkerframework/framework/type/TypesIntoElements.java
+++ b/framework/src/org/checkerframework/framework/type/TypesIntoElements.java
@@ -179,17 +179,13 @@ public class TypesIntoElements {
         AnnotatedTypeMirror type;
         int pos;
         if (ext == null) {
-            // The implicit superclass is always java.lang.Object.
-            // TODO: is this a good way to get the type?
             Type superClass = csym.getSuperclass();
             if (superClass.getKind() == TypeKind.NONE) {
                 // if superclass is NONE, then this class symbol is either an interface or it is java.lang.Object class itself.
                 // do nothing in both cases
                 return;
             } else {
-                type = atypeFactory.fromElement(
-                        csym.getSuperclass()
-                        .asElement());
+                type = atypeFactory.fromElement(csym.getSuperclass().asElement());
             }
             pos = -1;
         } else {

--- a/framework/src/org/checkerframework/framework/type/TypesIntoElements.java
+++ b/framework/src/org/checkerframework/framework/type/TypesIntoElements.java
@@ -60,12 +60,6 @@ public class TypesIntoElements {
 
         storeTypeParameters(processingEnv, types, atypeFactory, tree.getTypeParameters(), csym);
 
-        /* TODO: storing extends/implements types results in
-         * a strange error e.g. from the Nullness Checker.
-         * I think somewhere we take the annotations on extends/implements as
-         * the receiver annotation on a constructor, breaking logic there.
-         * I assume that the problem is the default that we use for these locations.
-         * Once we've decided the defaulting, enable this.*/
         storeClassExtends(processingEnv, types, atypeFactory, tree.getExtendsClause(), csym, -1);
         {
             int implidx = 0;
@@ -168,6 +162,17 @@ public class TypesIntoElements {
         addUniqueTypeCompounds(types, sym, tcs);
     }
 
+    /**
+     * given a class symbol {@code cysm}, and the extendsClause/implementsClause tree {@code ext}
+     * of the corresponding class tree, store the type compounds on {@code ext}
+     * @param processingEnv
+     * @param types
+     * @param atypeFactory
+     * @param ext
+     * @param csym the given class symbol
+     * @param implidx the type index of extends/implements, see jsr308 specification:
+     *      http://types.cs.washington.edu/jsr308/specification/java-annotation-design.html#class-file%3Aext%3Ari%3Aextends
+     */
     private static void storeClassExtends(
             ProcessingEnvironment processingEnv,
             Types types,

--- a/framework/src/org/checkerframework/framework/type/TypesIntoElements.java
+++ b/framework/src/org/checkerframework/framework/type/TypesIntoElements.java
@@ -163,8 +163,8 @@ public class TypesIntoElements {
     }
 
     /**
-     * given a class symbol {@code cysm}, and the extendsClause/implementsClause tree {@code ext}
-     * of the corresponding class tree, store the type compounds on {@code ext}
+     * given a class symbol {@code cysm}, and the extendsClause/implementsClause tree
+     * {@code ext}  of the corresponding class tree, store the type compounds on {@code ext}
      * @param processingEnv
      * @param types
      * @param atypeFactory
@@ -186,7 +186,8 @@ public class TypesIntoElements {
         if (ext == null) {
             Type superClass = csym.getSuperclass();
             if (superClass.getKind() == TypeKind.NONE) {
-                // if superclass is NONE, then this class symbol is either an interface or it is java.lang.Object class itself.
+                // if superclass is NONE, then this class symbol is either
+                // an interface or it is java.lang.Object class itself.
                 // do nothing in both cases
                 return;
             } else {

--- a/framework/src/org/checkerframework/framework/type/TypesIntoElements.java
+++ b/framework/src/org/checkerframework/framework/type/TypesIntoElements.java
@@ -65,7 +65,7 @@ public class TypesIntoElements {
          * I think somewhere we take the annotations on extends/implements as
          * the receiver annotation on a constructor, breaking logic there.
          * I assume that the problem is the default that we use for these locations.
-         * Once we've decided the defaulting, enable this.
+         * Once we've decided the defaulting, enable this.*/
         storeClassExtends(processingEnv, types, atypeFactory, tree.getExtendsClause(), csym, -1);
         {
             int implidx = 0;
@@ -74,7 +74,6 @@ public class TypesIntoElements {
                 ++implidx;
             }
         }
-        */
 
         for (Tree mem : tree.getMembers()) {
             if (mem.getKind() == Tree.Kind.METHOD) {
@@ -169,7 +168,6 @@ public class TypesIntoElements {
         addUniqueTypeCompounds(types, sym, tcs);
     }
 
-    @SuppressWarnings("unused") // TODO: see usage in comments above
     private static void storeClassExtends(
             ProcessingEnvironment processingEnv,
             Types types,
@@ -183,7 +181,16 @@ public class TypesIntoElements {
         if (ext == null) {
             // The implicit superclass is always java.lang.Object.
             // TODO: is this a good way to get the type?
-            type = atypeFactory.fromElement(csym.getSuperclass().asElement());
+            Type superClass = csym.getSuperclass();
+            if (superClass.getKind() == TypeKind.NONE) {
+                // if superclass is NONE, then this class symbol is either an interface or it is java.lang.Object class itself.
+                // do nothing in both cases
+                return;
+            } else {
+                type = atypeFactory.fromElement(
+                        csym.getSuperclass()
+                        .asElement());
+            }
             pos = -1;
         } else {
             type = atypeFactory.getAnnotatedTypeFromTypeTree(ext);

--- a/framework/src/org/checkerframework/framework/type/TypesIntoElements.java
+++ b/framework/src/org/checkerframework/framework/type/TypesIntoElements.java
@@ -163,8 +163,8 @@ public class TypesIntoElements {
     }
 
     /**
-     * given a class symbol {@code cysm}, and the extendsClause/implementsClause tree
-     * {@code ext}  of the corresponding class tree, store the type compounds on {@code ext}
+     * Given a class symbol {@code cysm}, and the extendsClause/implementsClause tree {@code ext}
+     * of the corresponding class tree, store the type compounds on {@code ext} into {@code csym}.
      * @param processingEnv
      * @param types
      * @param atypeFactory
@@ -191,7 +191,7 @@ public class TypesIntoElements {
                 // do nothing in both cases
                 return;
             } else {
-                type = atypeFactory.fromElement(csym.getSuperclass().asElement());
+                type = atypeFactory.fromElement(superClass.asElement());
             }
             pos = -1;
         } else {

--- a/framework/src/org/checkerframework/framework/util/element/SuperTypeApplier.java
+++ b/framework/src/org/checkerframework/framework/util/element/SuperTypeApplier.java
@@ -73,7 +73,7 @@ public class SuperTypeApplier extends IndexedElementAnnotationApplier {
      */
     @Override
     public int getElementIndex() {
-        return index;
+        return index == 0xffff ? -1 : index;
     }
 
     /**
@@ -81,7 +81,8 @@ public class SuperTypeApplier extends IndexedElementAnnotationApplier {
      */
     @Override
     public int getTypeCompoundIndex(Attribute.TypeCompound anno) {
-        return anno.getPosition().type_index;
+        int type_index = anno.getPosition().type_index;
+        return type_index == 0xffff ? -1 : type_index;
     }
 
     /**

--- a/framework/src/org/checkerframework/framework/util/element/SuperTypeApplier.java
+++ b/framework/src/org/checkerframework/framework/util/element/SuperTypeApplier.java
@@ -73,7 +73,7 @@ public class SuperTypeApplier extends IndexedElementAnnotationApplier {
      */
     @Override
     public int getElementIndex() {
-        return index == 0xffff ? -1 : index;
+        return index;
     }
 
     /**

--- a/framework/src/org/checkerframework/framework/util/element/SuperTypeApplier.java
+++ b/framework/src/org/checkerframework/framework/util/element/SuperTypeApplier.java
@@ -23,10 +23,9 @@ public class SuperTypeApplier extends IndexedElementAnnotationApplier {
     public static void annotateSupers(
             List<AnnotatedTypeMirror.AnnotatedDeclaredType> supertypes,
             TypeElement subtypeElement) {
-
-        final boolean isInterface = subtypeElement.getSuperclass().getKind() == TypeKind.NONE;
-
-        final int typeOffset = isInterface ? 0 : -1;
+        // typeOffset should always be -1. For a subtypeElement which represents an interface
+        // java.lang.Object would be it's supertype with type_idx = -1
+        final int typeOffset = -1;
 
         for (int i = 0; i < supertypes.size(); i++) {
             final AnnotatedTypeMirror supertype = supertypes.get(i);

--- a/framework/src/org/checkerframework/framework/util/element/SuperTypeApplier.java
+++ b/framework/src/org/checkerframework/framework/util/element/SuperTypeApplier.java
@@ -82,6 +82,14 @@ public class SuperTypeApplier extends IndexedElementAnnotationApplier {
     @Override
     public int getTypeCompoundIndex(Attribute.TypeCompound anno) {
         int type_index = anno.getPosition().type_index;
+        // TODO: this is a temporary workaround of a bug in jsr308-langtools
+        // The bug is due to a difference in:
+        //  com.sun.tools.classfile.TypeAnnotation.read_position(...) (correct one)
+        //  com.sun.tools.javac.jvm.ClassReader.readPosition() (buggy one)
+        // In latter method readPosition(...), in the switch-block, the case CLASS_EXTENDS should
+        // set the value read by nextChar() to -1 if the read value is 0xffff, just same as 
+        // the former method read_position(...) did.
+        // This workaround should be removed when the corresponding langtools bug is fixed.
         return type_index == 0xffff ? -1 : type_index;
     }
 

--- a/framework/src/org/checkerframework/framework/util/element/SuperTypeApplier.java
+++ b/framework/src/org/checkerframework/framework/util/element/SuperTypeApplier.java
@@ -5,7 +5,6 @@ import com.sun.tools.javac.code.Symbol;
 import com.sun.tools.javac.code.TargetType;
 import java.util.List;
 import javax.lang.model.element.TypeElement;
-import javax.lang.model.type.TypeKind;
 import org.checkerframework.framework.type.AnnotatedTypeMirror;
 
 /**
@@ -23,13 +22,15 @@ public class SuperTypeApplier extends IndexedElementAnnotationApplier {
     public static void annotateSupers(
             List<AnnotatedTypeMirror.AnnotatedDeclaredType> supertypes,
             TypeElement subtypeElement) {
-        // typeOffset should always be -1. For a subtypeElement which represents an interface
-        // java.lang.Object would be it's supertype with type_idx = -1
-        final int typeOffset = -1;
 
         for (int i = 0; i < supertypes.size(); i++) {
             final AnnotatedTypeMirror supertype = supertypes.get(i);
-            final int typeIndex = i + typeOffset;
+            // offset i by -1 since typeIndex should start from -1.
+            // -1 represents the supertype on (implicit) extends clause
+            // 0 or greater represents the supertype on (implicit) impelments clause
+            // details see jsr308 specification:
+            // http://types.cs.washington.edu/jsr308/specification/java-annotation-design.html#class-file%3Aext%3Ari%3Aextends
+            final int typeIndex = i - 1;
 
             (new SuperTypeApplier(supertype, subtypeElement, typeIndex)).extractAndApply();
         }


### PR DESCRIPTION
This PR resolved the set different sizes issues posted in pascaliUWat/CFI:
- https://github.com/pascaliUWat/checker-framework-inference/issues/15
- https://github.com/pascaliUWat/checker-framework-inference/issues/14

Also fixed bugs caused by enabling storing extends/implements for a class element : 1) add if-check in storeClassExtends(): do nothing when the passed class symbol is an interface or java.lang.Object. This fix a Nullpointer Exception. 2) changed typeOffset in SuperTypeAppiler#annotateSupers() always be -1. detail reason are comment in code