### PR TITLE
[dataflow] Add an abstract level of BinaryOperation and UnaryOperation in Node hierarchy

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -25,6 +25,7 @@ script:
 - REMOTE_ORIGIN_URL=`git config --get remote.origin.url`
 - >-
   docker run mdernst/ubuntu-for-cf-$JDKVER /bin/sh -c "true &&
+     echo $REMOTE_ORIGIN_URL &&
      export JAVA_HOME=\`which javac|xargs readlink -f|xargs dirname|xargs dirname\` &&
      git clone --quiet -b $TRAVIS_BRANCH --depth 3 $REMOTE_ORIGIN_URL checker-framework &&
      cd checker-framework &&

--- a/dataflow/src/org/checkerframework/dataflow/cfg/node/BinaryOperationNode.java
+++ b/dataflow/src/org/checkerframework/dataflow/cfg/node/BinaryOperationNode.java
@@ -1,0 +1,41 @@
+package org.checkerframework.dataflow.cfg.node;
+
+import com.sun.source.tree.BinaryTree;
+import java.util.Collection;
+import java.util.LinkedList;
+import org.checkerframework.javacutil.InternalUtils;
+
+public abstract class BinaryOperationNode extends Node {
+
+    protected BinaryTree tree;
+    protected Node left;
+    protected Node right;
+
+    public BinaryOperationNode(BinaryTree tree, Node left, Node right) {
+        super(InternalUtils.typeOf(tree));
+        this.tree = tree;
+        this.left = left;
+        this.right = right;
+    }
+
+    public Node getLeftOperand() {
+        return left;
+    }
+
+    public Node getRightOperand() {
+        return right;
+    }
+
+    @Override
+    public BinaryTree getTree() {
+        return tree;
+    }
+
+    @Override
+    public Collection<Node> getOperands() {
+        LinkedList<Node> list = new LinkedList<Node>();
+        list.add(getLeftOperand());
+        list.add(getRightOperand());
+        return list;
+    }
+}

--- a/dataflow/src/org/checkerframework/dataflow/cfg/node/BitwiseAndNode.java
+++ b/dataflow/src/org/checkerframework/dataflow/cfg/node/BitwiseAndNode.java
@@ -1,11 +1,8 @@
 package org.checkerframework.dataflow.cfg.node;
 
-import com.sun.source.tree.Tree;
+import com.sun.source.tree.BinaryTree;
 import com.sun.source.tree.Tree.Kind;
-import java.util.Collection;
-import java.util.LinkedList;
 import org.checkerframework.dataflow.util.HashCodeUtils;
-import org.checkerframework.javacutil.InternalUtils;
 
 /**
  * A node for the bitwise or logical (single bit) and operation:
@@ -18,31 +15,11 @@ import org.checkerframework.javacutil.InternalUtils;
  * @author Charlie Garrett
  *
  */
-public class BitwiseAndNode extends Node {
+public class BitwiseAndNode extends BinaryOperationNode {
 
-    protected Tree tree;
-    protected Node left;
-    protected Node right;
-
-    public BitwiseAndNode(Tree tree, Node left, Node right) {
-        super(InternalUtils.typeOf(tree));
+    public BitwiseAndNode(BinaryTree tree, Node left, Node right) {
+        super(tree, left, right);
         assert tree.getKind() == Kind.AND;
-        this.tree = tree;
-        this.left = left;
-        this.right = right;
-    }
-
-    public Node getLeftOperand() {
-        return left;
-    }
-
-    public Node getRightOperand() {
-        return right;
-    }
-
-    @Override
-    public Tree getTree() {
-        return tree;
     }
 
     @Override
@@ -68,13 +45,5 @@ public class BitwiseAndNode extends Node {
     @Override
     public int hashCode() {
         return HashCodeUtils.hash(getLeftOperand(), getRightOperand());
-    }
-
-    @Override
-    public Collection<Node> getOperands() {
-        LinkedList<Node> list = new LinkedList<Node>();
-        list.add(getLeftOperand());
-        list.add(getRightOperand());
-        return list;
     }
 }

--- a/dataflow/src/org/checkerframework/dataflow/cfg/node/BitwiseComplementNode.java
+++ b/dataflow/src/org/checkerframework/dataflow/cfg/node/BitwiseComplementNode.java
@@ -1,11 +1,8 @@
 package org.checkerframework.dataflow.cfg.node;
 
-import com.sun.source.tree.Tree;
 import com.sun.source.tree.Tree.Kind;
-import java.util.Collection;
-import java.util.Collections;
+import com.sun.source.tree.UnaryTree;
 import org.checkerframework.dataflow.util.HashCodeUtils;
-import org.checkerframework.javacutil.InternalUtils;
 
 /**
  * A node for the bitwise complement operation:
@@ -18,25 +15,11 @@ import org.checkerframework.javacutil.InternalUtils;
  * @author Charlie Garrett
  *
  */
-public class BitwiseComplementNode extends Node {
+public class BitwiseComplementNode extends UnaryOperationNode {
 
-    protected Tree tree;
-    protected Node operand;
-
-    public BitwiseComplementNode(Tree tree, Node operand) {
-        super(InternalUtils.typeOf(tree));
+    public BitwiseComplementNode(UnaryTree tree, Node operand) {
+        super(tree, operand);
         assert tree.getKind() == Kind.BITWISE_COMPLEMENT;
-        this.tree = tree;
-        this.operand = operand;
-    }
-
-    public Node getOperand() {
-        return operand;
-    }
-
-    @Override
-    public Tree getTree() {
-        return tree;
     }
 
     @Override
@@ -61,10 +44,5 @@ public class BitwiseComplementNode extends Node {
     @Override
     public int hashCode() {
         return HashCodeUtils.hash(getOperand());
-    }
-
-    @Override
-    public Collection<Node> getOperands() {
-        return Collections.singletonList(getOperand());
     }
 }

--- a/dataflow/src/org/checkerframework/dataflow/cfg/node/BitwiseOrNode.java
+++ b/dataflow/src/org/checkerframework/dataflow/cfg/node/BitwiseOrNode.java
@@ -1,11 +1,8 @@
 package org.checkerframework.dataflow.cfg.node;
 
-import com.sun.source.tree.Tree;
+import com.sun.source.tree.BinaryTree;
 import com.sun.source.tree.Tree.Kind;
-import java.util.Collection;
-import java.util.LinkedList;
 import org.checkerframework.dataflow.util.HashCodeUtils;
-import org.checkerframework.javacutil.InternalUtils;
 
 /**
  * A node for the bitwise or logical (single bit) or operation:
@@ -18,31 +15,11 @@ import org.checkerframework.javacutil.InternalUtils;
  * @author Charlie Garrett
  *
  */
-public class BitwiseOrNode extends Node {
+public class BitwiseOrNode extends BinaryOperationNode {
 
-    protected Tree tree;
-    protected Node left;
-    protected Node right;
-
-    public BitwiseOrNode(Tree tree, Node left, Node right) {
-        super(InternalUtils.typeOf(tree));
+    public BitwiseOrNode(BinaryTree tree, Node left, Node right) {
+        super(tree, left, right);
         assert tree.getKind() == Kind.OR;
-        this.tree = tree;
-        this.left = left;
-        this.right = right;
-    }
-
-    public Node getLeftOperand() {
-        return left;
-    }
-
-    public Node getRightOperand() {
-        return right;
-    }
-
-    @Override
-    public Tree getTree() {
-        return tree;
     }
 
     @Override
@@ -68,13 +45,5 @@ public class BitwiseOrNode extends Node {
     @Override
     public int hashCode() {
         return HashCodeUtils.hash(getLeftOperand(), getRightOperand());
-    }
-
-    @Override
-    public Collection<Node> getOperands() {
-        LinkedList<Node> list = new LinkedList<Node>();
-        list.add(getLeftOperand());
-        list.add(getRightOperand());
-        return list;
     }
 }

--- a/dataflow/src/org/checkerframework/dataflow/cfg/node/BitwiseXorNode.java
+++ b/dataflow/src/org/checkerframework/dataflow/cfg/node/BitwiseXorNode.java
@@ -1,11 +1,8 @@
 package org.checkerframework.dataflow.cfg.node;
 
-import com.sun.source.tree.Tree;
+import com.sun.source.tree.BinaryTree;
 import com.sun.source.tree.Tree.Kind;
-import java.util.Collection;
-import java.util.LinkedList;
 import org.checkerframework.dataflow.util.HashCodeUtils;
-import org.checkerframework.javacutil.InternalUtils;
 
 /**
  * A node for the bitwise or logical (single bit) xor operation:
@@ -18,31 +15,11 @@ import org.checkerframework.javacutil.InternalUtils;
  * @author Charlie Garrett
  *
  */
-public class BitwiseXorNode extends Node {
+public class BitwiseXorNode extends BinaryOperationNode {
 
-    protected Tree tree;
-    protected Node left;
-    protected Node right;
-
-    public BitwiseXorNode(Tree tree, Node left, Node right) {
-        super(InternalUtils.typeOf(tree));
+    public BitwiseXorNode(BinaryTree tree, Node left, Node right) {
+        super(tree, left, right);
         assert tree.getKind() == Kind.XOR;
-        this.tree = tree;
-        this.left = left;
-        this.right = right;
-    }
-
-    public Node getLeftOperand() {
-        return left;
-    }
-
-    public Node getRightOperand() {
-        return right;
-    }
-
-    @Override
-    public Tree getTree() {
-        return tree;
     }
 
     @Override
@@ -68,13 +45,5 @@ public class BitwiseXorNode extends Node {
     @Override
     public int hashCode() {
         return HashCodeUtils.hash(getLeftOperand(), getRightOperand());
-    }
-
-    @Override
-    public Collection<Node> getOperands() {
-        LinkedList<Node> list = new LinkedList<Node>();
-        list.add(getLeftOperand());
-        list.add(getRightOperand());
-        return list;
     }
 }

--- a/dataflow/src/org/checkerframework/dataflow/cfg/node/ConditionalAndNode.java
+++ b/dataflow/src/org/checkerframework/dataflow/cfg/node/ConditionalAndNode.java
@@ -2,10 +2,7 @@ package org.checkerframework.dataflow.cfg.node;
 
 import com.sun.source.tree.BinaryTree;
 import com.sun.source.tree.Tree.Kind;
-import java.util.Collection;
-import java.util.LinkedList;
 import org.checkerframework.dataflow.util.HashCodeUtils;
-import org.checkerframework.javacutil.InternalUtils;
 
 /**
  * A node for a conditional and expression:
@@ -18,31 +15,11 @@ import org.checkerframework.javacutil.InternalUtils;
  * @author Charlie Garrett
  *
  */
-public class ConditionalAndNode extends Node {
+public class ConditionalAndNode extends BinaryOperationNode {
 
-    protected BinaryTree tree;
-    protected Node lhs;
-    protected Node rhs;
-
-    public ConditionalAndNode(BinaryTree tree, Node lhs, Node rhs) {
-        super(InternalUtils.typeOf(tree));
+    public ConditionalAndNode(BinaryTree tree, Node left, Node right) {
+        super(tree, left, right);
         assert tree.getKind().equals(Kind.CONDITIONAL_AND);
-        this.tree = tree;
-        this.lhs = lhs;
-        this.rhs = rhs;
-    }
-
-    public Node getLeftOperand() {
-        return lhs;
-    }
-
-    public Node getRightOperand() {
-        return rhs;
-    }
-
-    @Override
-    public BinaryTree getTree() {
-        return tree;
     }
 
     @Override
@@ -68,13 +45,5 @@ public class ConditionalAndNode extends Node {
     @Override
     public int hashCode() {
         return HashCodeUtils.hash(getLeftOperand(), getRightOperand());
-    }
-
-    @Override
-    public Collection<Node> getOperands() {
-        LinkedList<Node> list = new LinkedList<Node>();
-        list.add(getLeftOperand());
-        list.add(getRightOperand());
-        return list;
     }
 }

--- a/dataflow/src/org/checkerframework/dataflow/cfg/node/ConditionalNotNode.java
+++ b/dataflow/src/org/checkerframework/dataflow/cfg/node/ConditionalNotNode.java
@@ -2,10 +2,7 @@ package org.checkerframework.dataflow.cfg.node;
 
 import com.sun.source.tree.Tree.Kind;
 import com.sun.source.tree.UnaryTree;
-import java.util.Collection;
-import java.util.Collections;
 import org.checkerframework.dataflow.util.HashCodeUtils;
-import org.checkerframework.javacutil.InternalUtils;
 
 /**
  * A node for a conditional not expression:
@@ -18,25 +15,11 @@ import org.checkerframework.javacutil.InternalUtils;
  * @author Charlie Garrett
  *
  */
-public class ConditionalNotNode extends Node {
-
-    protected UnaryTree tree;
-    protected Node operand;
+public class ConditionalNotNode extends UnaryOperationNode {
 
     public ConditionalNotNode(UnaryTree tree, Node operand) {
-        super(InternalUtils.typeOf(tree));
+        super(tree, operand);
         assert tree.getKind().equals(Kind.LOGICAL_COMPLEMENT);
-        this.tree = tree;
-        this.operand = operand;
-    }
-
-    public Node getOperand() {
-        return operand;
-    }
-
-    @Override
-    public UnaryTree getTree() {
-        return tree;
     }
 
     @Override
@@ -61,10 +44,5 @@ public class ConditionalNotNode extends Node {
     @Override
     public int hashCode() {
         return HashCodeUtils.hash(getOperand());
-    }
-
-    @Override
-    public Collection<Node> getOperands() {
-        return Collections.singletonList(getOperand());
     }
 }

--- a/dataflow/src/org/checkerframework/dataflow/cfg/node/ConditionalOrNode.java
+++ b/dataflow/src/org/checkerframework/dataflow/cfg/node/ConditionalOrNode.java
@@ -2,10 +2,7 @@ package org.checkerframework.dataflow.cfg.node;
 
 import com.sun.source.tree.BinaryTree;
 import com.sun.source.tree.Tree.Kind;
-import java.util.Collection;
-import java.util.LinkedList;
 import org.checkerframework.dataflow.util.HashCodeUtils;
-import org.checkerframework.javacutil.InternalUtils;
 
 /**
  * A node for a conditional or expression:
@@ -17,31 +14,11 @@ import org.checkerframework.javacutil.InternalUtils;
  * @author Stefan Heule
  *
  */
-public class ConditionalOrNode extends Node {
+public class ConditionalOrNode extends BinaryOperationNode {
 
-    protected BinaryTree tree;
-    protected Node lhs;
-    protected Node rhs;
-
-    public ConditionalOrNode(BinaryTree tree, Node lhs, Node rhs) {
-        super(InternalUtils.typeOf(tree));
+    public ConditionalOrNode(BinaryTree tree, Node left, Node right) {
+        super(tree, left, right);
         assert tree.getKind().equals(Kind.CONDITIONAL_OR);
-        this.tree = tree;
-        this.lhs = lhs;
-        this.rhs = rhs;
-    }
-
-    public Node getLeftOperand() {
-        return lhs;
-    }
-
-    public Node getRightOperand() {
-        return rhs;
-    }
-
-    @Override
-    public BinaryTree getTree() {
-        return tree;
     }
 
     @Override
@@ -67,13 +44,5 @@ public class ConditionalOrNode extends Node {
     @Override
     public int hashCode() {
         return HashCodeUtils.hash(getLeftOperand(), getRightOperand());
-    }
-
-    @Override
-    public Collection<Node> getOperands() {
-        LinkedList<Node> list = new LinkedList<Node>();
-        list.add(getLeftOperand());
-        list.add(getRightOperand());
-        return list;
     }
 }

--- a/dataflow/src/org/checkerframework/dataflow/cfg/node/EqualToNode.java
+++ b/dataflow/src/org/checkerframework/dataflow/cfg/node/EqualToNode.java
@@ -2,10 +2,7 @@ package org.checkerframework.dataflow.cfg.node;
 
 import com.sun.source.tree.BinaryTree;
 import com.sun.source.tree.Tree.Kind;
-import java.util.Collection;
-import java.util.LinkedList;
 import org.checkerframework.dataflow.util.HashCodeUtils;
-import org.checkerframework.javacutil.InternalUtils;
 
 /**
  * A node for an equality check:
@@ -17,31 +14,16 @@ import org.checkerframework.javacutil.InternalUtils;
  * @author Stefan Heule
  *
  */
-public class EqualToNode extends Node {
+public class EqualToNode extends BinaryOperationNode {
 
-    protected BinaryTree tree;
-    protected Node lhs;
-    protected Node rhs;
-
-    public EqualToNode(BinaryTree tree, Node lhs, Node rhs) {
-        super(InternalUtils.typeOf(tree));
+    public EqualToNode(BinaryTree tree, Node left, Node right) {
+        super(tree, left, right);
         assert tree.getKind().equals(Kind.EQUAL_TO);
-        this.tree = tree;
-        this.lhs = lhs;
-        this.rhs = rhs;
-    }
-
-    public Node getLeftOperand() {
-        return lhs;
-    }
-
-    public Node getRightOperand() {
-        return rhs;
     }
 
     @Override
     public BinaryTree getTree() {
-        return tree;
+        return (BinaryTree) tree;
     }
 
     @Override
@@ -67,13 +49,5 @@ public class EqualToNode extends Node {
     @Override
     public int hashCode() {
         return HashCodeUtils.hash(getLeftOperand(), getRightOperand());
-    }
-
-    @Override
-    public Collection<Node> getOperands() {
-        LinkedList<Node> list = new LinkedList<Node>();
-        list.add(getLeftOperand());
-        list.add(getRightOperand());
-        return list;
     }
 }

--- a/dataflow/src/org/checkerframework/dataflow/cfg/node/EqualToNode.java
+++ b/dataflow/src/org/checkerframework/dataflow/cfg/node/EqualToNode.java
@@ -22,11 +22,6 @@ public class EqualToNode extends BinaryOperationNode {
     }
 
     @Override
-    public BinaryTree getTree() {
-        return (BinaryTree) tree;
-    }
-
-    @Override
     public <R, P> R accept(NodeVisitor<R, P> visitor, P p) {
         return visitor.visitEqualTo(this, p);
     }

--- a/dataflow/src/org/checkerframework/dataflow/cfg/node/FloatingDivisionNode.java
+++ b/dataflow/src/org/checkerframework/dataflow/cfg/node/FloatingDivisionNode.java
@@ -1,11 +1,8 @@
 package org.checkerframework.dataflow.cfg.node;
 
-import com.sun.source.tree.Tree;
+import com.sun.source.tree.BinaryTree;
 import com.sun.source.tree.Tree.Kind;
-import java.util.Collection;
-import java.util.LinkedList;
 import org.checkerframework.dataflow.util.HashCodeUtils;
-import org.checkerframework.javacutil.InternalUtils;
 
 /**
  * A node for the floating-point division:
@@ -18,31 +15,11 @@ import org.checkerframework.javacutil.InternalUtils;
  * @author Charlie Garrett
  *
  */
-public class FloatingDivisionNode extends Node {
+public class FloatingDivisionNode extends BinaryOperationNode {
 
-    protected Tree tree;
-    protected Node left;
-    protected Node right;
-
-    public FloatingDivisionNode(Tree tree, Node left, Node right) {
-        super(InternalUtils.typeOf(tree));
+    public FloatingDivisionNode(BinaryTree tree, Node left, Node right) {
+        super(tree, left, right);
         assert tree.getKind() == Kind.DIVIDE;
-        this.tree = tree;
-        this.left = left;
-        this.right = right;
-    }
-
-    public Node getLeftOperand() {
-        return left;
-    }
-
-    public Node getRightOperand() {
-        return right;
-    }
-
-    @Override
-    public Tree getTree() {
-        return tree;
     }
 
     @Override
@@ -68,13 +45,5 @@ public class FloatingDivisionNode extends Node {
     @Override
     public int hashCode() {
         return HashCodeUtils.hash(getLeftOperand(), getRightOperand());
-    }
-
-    @Override
-    public Collection<Node> getOperands() {
-        LinkedList<Node> list = new LinkedList<Node>();
-        list.add(getLeftOperand());
-        list.add(getRightOperand());
-        return list;
     }
 }

--- a/dataflow/src/org/checkerframework/dataflow/cfg/node/FloatingRemainderNode.java
+++ b/dataflow/src/org/checkerframework/dataflow/cfg/node/FloatingRemainderNode.java
@@ -1,11 +1,8 @@
 package org.checkerframework.dataflow.cfg.node;
 
-import com.sun.source.tree.Tree;
+import com.sun.source.tree.BinaryTree;
 import com.sun.source.tree.Tree.Kind;
-import java.util.Collection;
-import java.util.LinkedList;
 import org.checkerframework.dataflow.util.HashCodeUtils;
-import org.checkerframework.javacutil.InternalUtils;
 
 /**
  * A node for the floating-point remainder:
@@ -18,31 +15,11 @@ import org.checkerframework.javacutil.InternalUtils;
  * @author Charlie Garrett
  *
  */
-public class FloatingRemainderNode extends Node {
+public class FloatingRemainderNode extends BinaryOperationNode {
 
-    protected Tree tree;
-    protected Node left;
-    protected Node right;
-
-    public FloatingRemainderNode(Tree tree, Node left, Node right) {
-        super(InternalUtils.typeOf(tree));
+    public FloatingRemainderNode(BinaryTree tree, Node left, Node right) {
+        super(tree, left, right);
         assert tree.getKind() == Kind.REMAINDER;
-        this.tree = tree;
-        this.left = left;
-        this.right = right;
-    }
-
-    public Node getLeftOperand() {
-        return left;
-    }
-
-    public Node getRightOperand() {
-        return right;
-    }
-
-    @Override
-    public Tree getTree() {
-        return tree;
     }
 
     @Override
@@ -68,13 +45,5 @@ public class FloatingRemainderNode extends Node {
     @Override
     public int hashCode() {
         return HashCodeUtils.hash(getLeftOperand(), getRightOperand());
-    }
-
-    @Override
-    public Collection<Node> getOperands() {
-        LinkedList<Node> list = new LinkedList<Node>();
-        list.add(getLeftOperand());
-        list.add(getRightOperand());
-        return list;
     }
 }

--- a/dataflow/src/org/checkerframework/dataflow/cfg/node/GreaterThanNode.java
+++ b/dataflow/src/org/checkerframework/dataflow/cfg/node/GreaterThanNode.java
@@ -1,11 +1,8 @@
 package org.checkerframework.dataflow.cfg.node;
 
-import com.sun.source.tree.Tree;
+import com.sun.source.tree.BinaryTree;
 import com.sun.source.tree.Tree.Kind;
-import java.util.Collection;
-import java.util.LinkedList;
 import org.checkerframework.dataflow.util.HashCodeUtils;
-import org.checkerframework.javacutil.InternalUtils;
 
 /**
  * A node for the greater than comparison:
@@ -18,31 +15,11 @@ import org.checkerframework.javacutil.InternalUtils;
  * @author Charlie Garrett
  *
  */
-public class GreaterThanNode extends Node {
+public class GreaterThanNode extends BinaryOperationNode {
 
-    protected Tree tree;
-    protected Node left;
-    protected Node right;
-
-    public GreaterThanNode(Tree tree, Node left, Node right) {
-        super(InternalUtils.typeOf(tree));
+    public GreaterThanNode(BinaryTree tree, Node left, Node right) {
+        super(tree, left, right);
         assert tree.getKind() == Kind.GREATER_THAN;
-        this.tree = tree;
-        this.left = left;
-        this.right = right;
-    }
-
-    public Node getLeftOperand() {
-        return left;
-    }
-
-    public Node getRightOperand() {
-        return right;
-    }
-
-    @Override
-    public Tree getTree() {
-        return tree;
     }
 
     @Override
@@ -68,13 +45,5 @@ public class GreaterThanNode extends Node {
     @Override
     public int hashCode() {
         return HashCodeUtils.hash(getLeftOperand(), getRightOperand());
-    }
-
-    @Override
-    public Collection<Node> getOperands() {
-        LinkedList<Node> list = new LinkedList<Node>();
-        list.add(getLeftOperand());
-        list.add(getRightOperand());
-        return list;
     }
 }

--- a/dataflow/src/org/checkerframework/dataflow/cfg/node/GreaterThanOrEqualNode.java
+++ b/dataflow/src/org/checkerframework/dataflow/cfg/node/GreaterThanOrEqualNode.java
@@ -1,11 +1,8 @@
 package org.checkerframework.dataflow.cfg.node;
 
-import com.sun.source.tree.Tree;
+import com.sun.source.tree.BinaryTree;
 import com.sun.source.tree.Tree.Kind;
-import java.util.Collection;
-import java.util.LinkedList;
 import org.checkerframework.dataflow.util.HashCodeUtils;
-import org.checkerframework.javacutil.InternalUtils;
 
 /**
  * A node for the greater than or equal comparison:
@@ -18,31 +15,11 @@ import org.checkerframework.javacutil.InternalUtils;
  * @author Charlie Garrett
  *
  */
-public class GreaterThanOrEqualNode extends Node {
+public class GreaterThanOrEqualNode extends BinaryOperationNode {
 
-    protected Tree tree;
-    protected Node left;
-    protected Node right;
-
-    public GreaterThanOrEqualNode(Tree tree, Node left, Node right) {
-        super(InternalUtils.typeOf(tree));
+    public GreaterThanOrEqualNode(BinaryTree tree, Node left, Node right) {
+        super(tree, left, right);
         assert tree.getKind() == Kind.GREATER_THAN_EQUAL;
-        this.tree = tree;
-        this.left = left;
-        this.right = right;
-    }
-
-    public Node getLeftOperand() {
-        return left;
-    }
-
-    public Node getRightOperand() {
-        return right;
-    }
-
-    @Override
-    public Tree getTree() {
-        return tree;
     }
 
     @Override
@@ -68,13 +45,5 @@ public class GreaterThanOrEqualNode extends Node {
     @Override
     public int hashCode() {
         return HashCodeUtils.hash(getLeftOperand(), getRightOperand());
-    }
-
-    @Override
-    public Collection<Node> getOperands() {
-        LinkedList<Node> list = new LinkedList<Node>();
-        list.add(getLeftOperand());
-        list.add(getRightOperand());
-        return list;
     }
 }

--- a/dataflow/src/org/checkerframework/dataflow/cfg/node/IntegerDivisionNode.java
+++ b/dataflow/src/org/checkerframework/dataflow/cfg/node/IntegerDivisionNode.java
@@ -1,11 +1,8 @@
 package org.checkerframework.dataflow.cfg.node;
 
-import com.sun.source.tree.Tree;
+import com.sun.source.tree.BinaryTree;
 import com.sun.source.tree.Tree.Kind;
-import java.util.Collection;
-import java.util.LinkedList;
 import org.checkerframework.dataflow.util.HashCodeUtils;
-import org.checkerframework.javacutil.InternalUtils;
 
 /**
  * A node for the integer division:
@@ -18,31 +15,11 @@ import org.checkerframework.javacutil.InternalUtils;
  * @author Charlie Garrett
  *
  */
-public class IntegerDivisionNode extends Node {
+public class IntegerDivisionNode extends BinaryOperationNode {
 
-    protected Tree tree;
-    protected Node left;
-    protected Node right;
-
-    public IntegerDivisionNode(Tree tree, Node left, Node right) {
-        super(InternalUtils.typeOf(tree));
+    public IntegerDivisionNode(BinaryTree tree, Node left, Node right) {
+        super(tree, left, right);
         assert tree.getKind() == Kind.DIVIDE;
-        this.tree = tree;
-        this.left = left;
-        this.right = right;
-    }
-
-    public Node getLeftOperand() {
-        return left;
-    }
-
-    public Node getRightOperand() {
-        return right;
-    }
-
-    @Override
-    public Tree getTree() {
-        return tree;
     }
 
     @Override
@@ -68,13 +45,5 @@ public class IntegerDivisionNode extends Node {
     @Override
     public int hashCode() {
         return HashCodeUtils.hash(getLeftOperand(), getRightOperand());
-    }
-
-    @Override
-    public Collection<Node> getOperands() {
-        LinkedList<Node> list = new LinkedList<Node>();
-        list.add(getLeftOperand());
-        list.add(getRightOperand());
-        return list;
     }
 }

--- a/dataflow/src/org/checkerframework/dataflow/cfg/node/IntegerRemainderNode.java
+++ b/dataflow/src/org/checkerframework/dataflow/cfg/node/IntegerRemainderNode.java
@@ -1,11 +1,8 @@
 package org.checkerframework.dataflow.cfg.node;
 
-import com.sun.source.tree.Tree;
+import com.sun.source.tree.BinaryTree;
 import com.sun.source.tree.Tree.Kind;
-import java.util.Collection;
-import java.util.LinkedList;
 import org.checkerframework.dataflow.util.HashCodeUtils;
-import org.checkerframework.javacutil.InternalUtils;
 
 /**
  * A node for the integer remainder:
@@ -18,31 +15,11 @@ import org.checkerframework.javacutil.InternalUtils;
  * @author Charlie Garrett
  *
  */
-public class IntegerRemainderNode extends Node {
+public class IntegerRemainderNode extends BinaryOperationNode {
 
-    protected Tree tree;
-    protected Node left;
-    protected Node right;
-
-    public IntegerRemainderNode(Tree tree, Node left, Node right) {
-        super(InternalUtils.typeOf(tree));
+    public IntegerRemainderNode(BinaryTree tree, Node left, Node right) {
+        super(tree, left, right);
         assert tree.getKind() == Kind.REMAINDER;
-        this.tree = tree;
-        this.left = left;
-        this.right = right;
-    }
-
-    public Node getLeftOperand() {
-        return left;
-    }
-
-    public Node getRightOperand() {
-        return right;
-    }
-
-    @Override
-    public Tree getTree() {
-        return tree;
     }
 
     @Override
@@ -68,13 +45,5 @@ public class IntegerRemainderNode extends Node {
     @Override
     public int hashCode() {
         return HashCodeUtils.hash(getLeftOperand(), getRightOperand());
-    }
-
-    @Override
-    public Collection<Node> getOperands() {
-        LinkedList<Node> list = new LinkedList<Node>();
-        list.add(getLeftOperand());
-        list.add(getRightOperand());
-        return list;
     }
 }

--- a/dataflow/src/org/checkerframework/dataflow/cfg/node/LeftShiftNode.java
+++ b/dataflow/src/org/checkerframework/dataflow/cfg/node/LeftShiftNode.java
@@ -1,11 +1,8 @@
 package org.checkerframework.dataflow.cfg.node;
 
-import com.sun.source.tree.Tree;
+import com.sun.source.tree.BinaryTree;
 import com.sun.source.tree.Tree.Kind;
-import java.util.Collection;
-import java.util.LinkedList;
 import org.checkerframework.dataflow.util.HashCodeUtils;
-import org.checkerframework.javacutil.InternalUtils;
 
 /**
  * A node for bitwise left shift operations:
@@ -18,31 +15,11 @@ import org.checkerframework.javacutil.InternalUtils;
  * @author Charlie Garrett
  *
  */
-public class LeftShiftNode extends Node {
+public class LeftShiftNode extends BinaryOperationNode {
 
-    protected Tree tree;
-    protected Node left;
-    protected Node right;
-
-    public LeftShiftNode(Tree tree, Node left, Node right) {
-        super(InternalUtils.typeOf(tree));
+    public LeftShiftNode(BinaryTree tree, Node left, Node right) {
+        super(tree, left, right);
         assert tree.getKind() == Kind.LEFT_SHIFT;
-        this.tree = tree;
-        this.left = left;
-        this.right = right;
-    }
-
-    public Node getLeftOperand() {
-        return left;
-    }
-
-    public Node getRightOperand() {
-        return right;
-    }
-
-    @Override
-    public Tree getTree() {
-        return tree;
     }
 
     @Override
@@ -68,13 +45,5 @@ public class LeftShiftNode extends Node {
     @Override
     public int hashCode() {
         return HashCodeUtils.hash(getLeftOperand(), getRightOperand());
-    }
-
-    @Override
-    public Collection<Node> getOperands() {
-        LinkedList<Node> list = new LinkedList<Node>();
-        list.add(getLeftOperand());
-        list.add(getRightOperand());
-        return list;
     }
 }

--- a/dataflow/src/org/checkerframework/dataflow/cfg/node/LessThanNode.java
+++ b/dataflow/src/org/checkerframework/dataflow/cfg/node/LessThanNode.java
@@ -1,7 +1,7 @@
 package org.checkerframework.dataflow.cfg.node;
 
-import com.sun.source.tree.Tree;
 import com.sun.source.tree.BinaryTree;
+import com.sun.source.tree.Tree;
 import com.sun.source.tree.Tree.Kind;
 import org.checkerframework.dataflow.util.HashCodeUtils;
 

--- a/dataflow/src/org/checkerframework/dataflow/cfg/node/LessThanNode.java
+++ b/dataflow/src/org/checkerframework/dataflow/cfg/node/LessThanNode.java
@@ -1,5 +1,6 @@
 package org.checkerframework.dataflow.cfg.node;
 
+import com.sun.source.tree.Tree;
 import com.sun.source.tree.BinaryTree;
 import com.sun.source.tree.Tree.Kind;
 import org.checkerframework.dataflow.util.HashCodeUtils;

--- a/dataflow/src/org/checkerframework/dataflow/cfg/node/LessThanNode.java
+++ b/dataflow/src/org/checkerframework/dataflow/cfg/node/LessThanNode.java
@@ -1,11 +1,8 @@
 package org.checkerframework.dataflow.cfg.node;
 
-import com.sun.source.tree.Tree;
+import com.sun.source.tree.BinaryTree;
 import com.sun.source.tree.Tree.Kind;
-import java.util.Collection;
-import java.util.LinkedList;
 import org.checkerframework.dataflow.util.HashCodeUtils;
-import org.checkerframework.javacutil.InternalUtils;
 
 /**
  * A node for the less than comparison:
@@ -20,31 +17,11 @@ import org.checkerframework.javacutil.InternalUtils;
  * @author Charlie Garrett
  *
  */
-public class LessThanNode extends Node {
+public class LessThanNode extends BinaryOperationNode {
 
-    protected Tree tree;
-    protected Node left;
-    protected Node right;
-
-    public LessThanNode(Tree tree, Node left, Node right) {
-        super(InternalUtils.typeOf(tree));
+    public LessThanNode(BinaryTree tree, Node left, Node right) {
+        super(tree, left, right);
         assert tree.getKind() == Kind.LESS_THAN;
-        this.tree = tree;
-        this.left = left;
-        this.right = right;
-    }
-
-    public Node getLeftOperand() {
-        return left;
-    }
-
-    public Node getRightOperand() {
-        return right;
-    }
-
-    @Override
-    public Tree getTree() {
-        return tree;
     }
 
     @Override
@@ -70,13 +47,5 @@ public class LessThanNode extends Node {
     @Override
     public int hashCode() {
         return HashCodeUtils.hash(getLeftOperand(), getRightOperand());
-    }
-
-    @Override
-    public Collection<Node> getOperands() {
-        LinkedList<Node> list = new LinkedList<Node>();
-        list.add(getLeftOperand());
-        list.add(getRightOperand());
-        return list;
     }
 }

--- a/dataflow/src/org/checkerframework/dataflow/cfg/node/LessThanOrEqualNode.java
+++ b/dataflow/src/org/checkerframework/dataflow/cfg/node/LessThanOrEqualNode.java
@@ -1,11 +1,8 @@
 package org.checkerframework.dataflow.cfg.node;
 
-import com.sun.source.tree.Tree;
+import com.sun.source.tree.BinaryTree;
 import com.sun.source.tree.Tree.Kind;
-import java.util.Collection;
-import java.util.LinkedList;
 import org.checkerframework.dataflow.util.HashCodeUtils;
-import org.checkerframework.javacutil.InternalUtils;
 
 /**
  * A node for the less than or equal comparison:
@@ -18,31 +15,11 @@ import org.checkerframework.javacutil.InternalUtils;
  * @author Charlie Garrett
  *
  */
-public class LessThanOrEqualNode extends Node {
+public class LessThanOrEqualNode extends BinaryOperationNode {
 
-    protected Tree tree;
-    protected Node left;
-    protected Node right;
-
-    public LessThanOrEqualNode(Tree tree, Node left, Node right) {
-        super(InternalUtils.typeOf(tree));
+    public LessThanOrEqualNode(BinaryTree tree, Node left, Node right) {
+        super(tree, left, right);
         assert tree.getKind() == Kind.LESS_THAN_EQUAL;
-        this.tree = tree;
-        this.left = left;
-        this.right = right;
-    }
-
-    public Node getLeftOperand() {
-        return left;
-    }
-
-    public Node getRightOperand() {
-        return right;
-    }
-
-    @Override
-    public Tree getTree() {
-        return tree;
     }
 
     @Override
@@ -68,13 +45,5 @@ public class LessThanOrEqualNode extends Node {
     @Override
     public int hashCode() {
         return HashCodeUtils.hash(getLeftOperand(), getRightOperand());
-    }
-
-    @Override
-    public Collection<Node> getOperands() {
-        LinkedList<Node> list = new LinkedList<Node>();
-        list.add(getLeftOperand());
-        list.add(getRightOperand());
-        return list;
     }
 }

--- a/dataflow/src/org/checkerframework/dataflow/cfg/node/NotEqualNode.java
+++ b/dataflow/src/org/checkerframework/dataflow/cfg/node/NotEqualNode.java
@@ -1,11 +1,8 @@
 package org.checkerframework.dataflow.cfg.node;
 
-import com.sun.source.tree.Tree;
+import com.sun.source.tree.BinaryTree;
 import com.sun.source.tree.Tree.Kind;
-import java.util.Collection;
-import java.util.LinkedList;
 import org.checkerframework.dataflow.util.HashCodeUtils;
-import org.checkerframework.javacutil.InternalUtils;
 
 /**
  * A node for the not equal comparison:
@@ -18,31 +15,11 @@ import org.checkerframework.javacutil.InternalUtils;
  * @author Charlie Garrett
  *
  */
-public class NotEqualNode extends Node {
+public class NotEqualNode extends BinaryOperationNode {
 
-    protected Tree tree;
-    protected Node left;
-    protected Node right;
-
-    public NotEqualNode(Tree tree, Node left, Node right) {
-        super(InternalUtils.typeOf(tree));
+    public NotEqualNode(BinaryTree tree, Node left, Node right) {
+        super(tree, left, right);
         assert tree.getKind() == Kind.NOT_EQUAL_TO;
-        this.tree = tree;
-        this.left = left;
-        this.right = right;
-    }
-
-    public Node getLeftOperand() {
-        return left;
-    }
-
-    public Node getRightOperand() {
-        return right;
-    }
-
-    @Override
-    public Tree getTree() {
-        return tree;
     }
 
     @Override
@@ -68,13 +45,5 @@ public class NotEqualNode extends Node {
     @Override
     public int hashCode() {
         return HashCodeUtils.hash(getLeftOperand(), getRightOperand());
-    }
-
-    @Override
-    public Collection<Node> getOperands() {
-        LinkedList<Node> list = new LinkedList<Node>();
-        list.add(getLeftOperand());
-        list.add(getRightOperand());
-        return list;
     }
 }

--- a/dataflow/src/org/checkerframework/dataflow/cfg/node/NumericalAdditionNode.java
+++ b/dataflow/src/org/checkerframework/dataflow/cfg/node/NumericalAdditionNode.java
@@ -1,11 +1,8 @@
 package org.checkerframework.dataflow.cfg.node;
 
-import com.sun.source.tree.Tree;
+import com.sun.source.tree.BinaryTree;
 import com.sun.source.tree.Tree.Kind;
-import java.util.Collection;
-import java.util.LinkedList;
 import org.checkerframework.dataflow.util.HashCodeUtils;
-import org.checkerframework.javacutil.InternalUtils;
 
 /**
  * A node for the numerical addition:
@@ -17,31 +14,11 @@ import org.checkerframework.javacutil.InternalUtils;
  * @author Stefan Heule
  *
  */
-public class NumericalAdditionNode extends Node {
+public class NumericalAdditionNode extends BinaryOperationNode {
 
-    protected Tree tree;
-    protected Node left;
-    protected Node right;
-
-    public NumericalAdditionNode(Tree tree, Node left, Node right) {
-        super(InternalUtils.typeOf(tree));
+    public NumericalAdditionNode(BinaryTree tree, Node left, Node right) {
+        super(tree, left, right);
         assert tree.getKind() == Kind.PLUS || tree.getKind() == Kind.PLUS_ASSIGNMENT;
-        this.tree = tree;
-        this.left = left;
-        this.right = right;
-    }
-
-    public Node getLeftOperand() {
-        return left;
-    }
-
-    public Node getRightOperand() {
-        return right;
-    }
-
-    @Override
-    public Tree getTree() {
-        return tree;
     }
 
     @Override
@@ -67,13 +44,5 @@ public class NumericalAdditionNode extends Node {
     @Override
     public int hashCode() {
         return HashCodeUtils.hash(getLeftOperand(), getRightOperand());
-    }
-
-    @Override
-    public Collection<Node> getOperands() {
-        LinkedList<Node> list = new LinkedList<Node>();
-        list.add(getLeftOperand());
-        list.add(getRightOperand());
-        return list;
     }
 }

--- a/dataflow/src/org/checkerframework/dataflow/cfg/node/NumericalMinusNode.java
+++ b/dataflow/src/org/checkerframework/dataflow/cfg/node/NumericalMinusNode.java
@@ -1,11 +1,8 @@
 package org.checkerframework.dataflow.cfg.node;
 
-import com.sun.source.tree.Tree;
 import com.sun.source.tree.Tree.Kind;
-import java.util.Collection;
-import java.util.Collections;
+import com.sun.source.tree.UnaryTree;
 import org.checkerframework.dataflow.util.HashCodeUtils;
-import org.checkerframework.javacutil.InternalUtils;
 
 /**
  * A node for the unary minus operation:
@@ -18,25 +15,11 @@ import org.checkerframework.javacutil.InternalUtils;
  * @author Charlie Garrett
  *
  */
-public class NumericalMinusNode extends Node {
+public class NumericalMinusNode extends UnaryOperationNode {
 
-    protected Tree tree;
-    protected Node operand;
-
-    public NumericalMinusNode(Tree tree, Node operand) {
-        super(InternalUtils.typeOf(tree));
+    public NumericalMinusNode(UnaryTree tree, Node operand) {
+        super(tree, operand);
         assert tree.getKind() == Kind.UNARY_MINUS;
-        this.tree = tree;
-        this.operand = operand;
-    }
-
-    public Node getOperand() {
-        return operand;
-    }
-
-    @Override
-    public Tree getTree() {
-        return tree;
     }
 
     @Override
@@ -61,10 +44,5 @@ public class NumericalMinusNode extends Node {
     @Override
     public int hashCode() {
         return HashCodeUtils.hash(getOperand());
-    }
-
-    @Override
-    public Collection<Node> getOperands() {
-        return Collections.singletonList(getOperand());
     }
 }

--- a/dataflow/src/org/checkerframework/dataflow/cfg/node/NumericalMultiplicationNode.java
+++ b/dataflow/src/org/checkerframework/dataflow/cfg/node/NumericalMultiplicationNode.java
@@ -1,11 +1,8 @@
 package org.checkerframework.dataflow.cfg.node;
 
-import com.sun.source.tree.Tree;
+import com.sun.source.tree.BinaryTree;
 import com.sun.source.tree.Tree.Kind;
-import java.util.Collection;
-import java.util.LinkedList;
 import org.checkerframework.dataflow.util.HashCodeUtils;
-import org.checkerframework.javacutil.InternalUtils;
 
 /**
  * A node for the numerical multiplication:
@@ -18,31 +15,11 @@ import org.checkerframework.javacutil.InternalUtils;
  * @author Charlie Garrett
  *
  */
-public class NumericalMultiplicationNode extends Node {
+public class NumericalMultiplicationNode extends BinaryOperationNode {
 
-    protected Tree tree;
-    protected Node left;
-    protected Node right;
-
-    public NumericalMultiplicationNode(Tree tree, Node left, Node right) {
-        super(InternalUtils.typeOf(tree));
+    public NumericalMultiplicationNode(BinaryTree tree, Node left, Node right) {
+        super(tree, left, right);
         assert tree.getKind() == Kind.MULTIPLY;
-        this.tree = tree;
-        this.left = left;
-        this.right = right;
-    }
-
-    public Node getLeftOperand() {
-        return left;
-    }
-
-    public Node getRightOperand() {
-        return right;
-    }
-
-    @Override
-    public Tree getTree() {
-        return tree;
     }
 
     @Override
@@ -68,13 +45,5 @@ public class NumericalMultiplicationNode extends Node {
     @Override
     public int hashCode() {
         return HashCodeUtils.hash(getLeftOperand(), getRightOperand());
-    }
-
-    @Override
-    public Collection<Node> getOperands() {
-        LinkedList<Node> list = new LinkedList<Node>();
-        list.add(getLeftOperand());
-        list.add(getRightOperand());
-        return list;
     }
 }

--- a/dataflow/src/org/checkerframework/dataflow/cfg/node/NumericalPlusNode.java
+++ b/dataflow/src/org/checkerframework/dataflow/cfg/node/NumericalPlusNode.java
@@ -1,11 +1,8 @@
 package org.checkerframework.dataflow.cfg.node;
 
-import com.sun.source.tree.Tree;
 import com.sun.source.tree.Tree.Kind;
-import java.util.Collection;
-import java.util.Collections;
+import com.sun.source.tree.UnaryTree;
 import org.checkerframework.dataflow.util.HashCodeUtils;
-import org.checkerframework.javacutil.InternalUtils;
 
 /**
  * A node for the unary plus operation:
@@ -18,25 +15,11 @@ import org.checkerframework.javacutil.InternalUtils;
  * @author Charlie Garrett
  *
  */
-public class NumericalPlusNode extends Node {
+public class NumericalPlusNode extends UnaryOperationNode {
 
-    protected Tree tree;
-    protected Node operand;
-
-    public NumericalPlusNode(Tree tree, Node operand) {
-        super(InternalUtils.typeOf(tree));
+    public NumericalPlusNode(UnaryTree tree, Node operand) {
+        super(tree, operand);
         assert tree.getKind() == Kind.UNARY_PLUS;
-        this.tree = tree;
-        this.operand = operand;
-    }
-
-    public Node getOperand() {
-        return operand;
-    }
-
-    @Override
-    public Tree getTree() {
-        return tree;
     }
 
     @Override
@@ -61,10 +44,5 @@ public class NumericalPlusNode extends Node {
     @Override
     public int hashCode() {
         return HashCodeUtils.hash(getOperand());
-    }
-
-    @Override
-    public Collection<Node> getOperands() {
-        return Collections.singletonList(getOperand());
     }
 }

--- a/dataflow/src/org/checkerframework/dataflow/cfg/node/NumericalSubtractionNode.java
+++ b/dataflow/src/org/checkerframework/dataflow/cfg/node/NumericalSubtractionNode.java
@@ -1,11 +1,8 @@
 package org.checkerframework.dataflow.cfg.node;
 
-import com.sun.source.tree.Tree;
+import com.sun.source.tree.BinaryTree;
 import com.sun.source.tree.Tree.Kind;
-import java.util.Collection;
-import java.util.LinkedList;
 import org.checkerframework.dataflow.util.HashCodeUtils;
-import org.checkerframework.javacutil.InternalUtils;
 
 /**
  * A node for the numerical subtraction:
@@ -18,31 +15,11 @@ import org.checkerframework.javacutil.InternalUtils;
  * @author Charlie Garrett
  *
  */
-public class NumericalSubtractionNode extends Node {
+public class NumericalSubtractionNode extends BinaryOperationNode {
 
-    protected Tree tree;
-    protected Node left;
-    protected Node right;
-
-    public NumericalSubtractionNode(Tree tree, Node left, Node right) {
-        super(InternalUtils.typeOf(tree));
+    public NumericalSubtractionNode(BinaryTree tree, Node left, Node right) {
+        super(tree, left, right);
         assert tree.getKind() == Kind.MINUS;
-        this.tree = tree;
-        this.left = left;
-        this.right = right;
-    }
-
-    public Node getLeftOperand() {
-        return left;
-    }
-
-    public Node getRightOperand() {
-        return right;
-    }
-
-    @Override
-    public Tree getTree() {
-        return tree;
     }
 
     @Override
@@ -68,13 +45,5 @@ public class NumericalSubtractionNode extends Node {
     @Override
     public int hashCode() {
         return HashCodeUtils.hash(getLeftOperand(), getRightOperand());
-    }
-
-    @Override
-    public Collection<Node> getOperands() {
-        LinkedList<Node> list = new LinkedList<Node>();
-        list.add(getLeftOperand());
-        list.add(getRightOperand());
-        return list;
     }
 }

--- a/dataflow/src/org/checkerframework/dataflow/cfg/node/SignedRightShiftNode.java
+++ b/dataflow/src/org/checkerframework/dataflow/cfg/node/SignedRightShiftNode.java
@@ -1,11 +1,8 @@
 package org.checkerframework.dataflow.cfg.node;
 
-import com.sun.source.tree.Tree;
+import com.sun.source.tree.BinaryTree;
 import com.sun.source.tree.Tree.Kind;
-import java.util.Collection;
-import java.util.LinkedList;
 import org.checkerframework.dataflow.util.HashCodeUtils;
-import org.checkerframework.javacutil.InternalUtils;
 
 /**
  * A node for bitwise right shift operations with sign extension:
@@ -18,31 +15,11 @@ import org.checkerframework.javacutil.InternalUtils;
  * @author Charlie Garrett
  *
  */
-public class SignedRightShiftNode extends Node {
+public class SignedRightShiftNode extends BinaryOperationNode {
 
-    protected Tree tree;
-    protected Node left;
-    protected Node right;
-
-    public SignedRightShiftNode(Tree tree, Node left, Node right) {
-        super(InternalUtils.typeOf(tree));
+    public SignedRightShiftNode(BinaryTree tree, Node left, Node right) {
+        super(tree, left, right);
         assert tree.getKind() == Kind.RIGHT_SHIFT;
-        this.tree = tree;
-        this.left = left;
-        this.right = right;
-    }
-
-    public Node getLeftOperand() {
-        return left;
-    }
-
-    public Node getRightOperand() {
-        return right;
-    }
-
-    @Override
-    public Tree getTree() {
-        return tree;
     }
 
     @Override
@@ -68,13 +45,5 @@ public class SignedRightShiftNode extends Node {
     @Override
     public int hashCode() {
         return HashCodeUtils.hash(getLeftOperand(), getRightOperand());
-    }
-
-    @Override
-    public Collection<Node> getOperands() {
-        LinkedList<Node> list = new LinkedList<Node>();
-        list.add(getLeftOperand());
-        list.add(getRightOperand());
-        return list;
     }
 }

--- a/dataflow/src/org/checkerframework/dataflow/cfg/node/StringConcatenateNode.java
+++ b/dataflow/src/org/checkerframework/dataflow/cfg/node/StringConcatenateNode.java
@@ -1,11 +1,8 @@
 package org.checkerframework.dataflow.cfg.node;
 
-import com.sun.source.tree.Tree;
+import com.sun.source.tree.BinaryTree;
 import com.sun.source.tree.Tree.Kind;
-import java.util.Collection;
-import java.util.LinkedList;
 import org.checkerframework.dataflow.util.HashCodeUtils;
-import org.checkerframework.javacutil.InternalUtils;
 
 /**
  * A node for string concatenation:
@@ -18,31 +15,11 @@ import org.checkerframework.javacutil.InternalUtils;
  * @author Charlie Garrett
  *
  */
-public class StringConcatenateNode extends Node {
+public class StringConcatenateNode extends BinaryOperationNode {
 
-    protected Tree tree;
-    protected Node left;
-    protected Node right;
-
-    public StringConcatenateNode(Tree tree, Node left, Node right) {
-        super(InternalUtils.typeOf(tree));
+    public StringConcatenateNode(BinaryTree tree, Node left, Node right) {
+        super(tree, left, right);
         assert tree.getKind() == Kind.PLUS;
-        this.tree = tree;
-        this.left = left;
-        this.right = right;
-    }
-
-    public Node getLeftOperand() {
-        return left;
-    }
-
-    public Node getRightOperand() {
-        return right;
-    }
-
-    @Override
-    public Tree getTree() {
-        return tree;
     }
 
     @Override
@@ -68,13 +45,5 @@ public class StringConcatenateNode extends Node {
     @Override
     public int hashCode() {
         return HashCodeUtils.hash(getLeftOperand(), getRightOperand());
-    }
-
-    @Override
-    public Collection<Node> getOperands() {
-        LinkedList<Node> list = new LinkedList<Node>();
-        list.add(getLeftOperand());
-        list.add(getRightOperand());
-        return list;
     }
 }

--- a/dataflow/src/org/checkerframework/dataflow/cfg/node/UnaryOperationNode.java
+++ b/dataflow/src/org/checkerframework/dataflow/cfg/node/UnaryOperationNode.java
@@ -1,0 +1,32 @@
+package org.checkerframework.dataflow.cfg.node;
+
+import com.sun.source.tree.UnaryTree;
+import java.util.Collection;
+import java.util.Collections;
+import org.checkerframework.javacutil.InternalUtils;
+
+public abstract class UnaryOperationNode extends Node {
+
+    protected UnaryTree tree;
+    protected Node operand;
+
+    public UnaryOperationNode(UnaryTree tree, Node operand) {
+        super(InternalUtils.typeOf(tree));
+        this.tree = tree;
+        this.operand = operand;
+    }
+
+    public Node getOperand() {
+        return this.operand;
+    }
+
+    @Override
+    public UnaryTree getTree() {
+        return tree;
+    }
+
+    @Override
+    public Collection<Node> getOperands() {
+        return Collections.singletonList(getOperand());
+    }
+}

--- a/dataflow/src/org/checkerframework/dataflow/cfg/node/UnsignedRightShiftNode.java
+++ b/dataflow/src/org/checkerframework/dataflow/cfg/node/UnsignedRightShiftNode.java
@@ -1,11 +1,8 @@
 package org.checkerframework.dataflow.cfg.node;
 
-import com.sun.source.tree.Tree;
+import com.sun.source.tree.BinaryTree;
 import com.sun.source.tree.Tree.Kind;
-import java.util.Collection;
-import java.util.LinkedList;
 import org.checkerframework.dataflow.util.HashCodeUtils;
-import org.checkerframework.javacutil.InternalUtils;
 
 /**
  * A node for bitwise right shift operations with zero extension:
@@ -18,31 +15,11 @@ import org.checkerframework.javacutil.InternalUtils;
  * @author Charlie Garrett
  *
  */
-public class UnsignedRightShiftNode extends Node {
+public class UnsignedRightShiftNode extends BinaryOperationNode {
 
-    protected Tree tree;
-    protected Node left;
-    protected Node right;
-
-    public UnsignedRightShiftNode(Tree tree, Node left, Node right) {
-        super(InternalUtils.typeOf(tree));
+    public UnsignedRightShiftNode(BinaryTree tree, Node left, Node right) {
+        super(tree, left, right);
         assert tree.getKind() == Kind.UNSIGNED_RIGHT_SHIFT;
-        this.tree = tree;
-        this.left = left;
-        this.right = right;
-    }
-
-    public Node getLeftOperand() {
-        return left;
-    }
-
-    public Node getRightOperand() {
-        return right;
-    }
-
-    @Override
-    public Tree getTree() {
-        return tree;
     }
 
     @Override
@@ -68,13 +45,5 @@ public class UnsignedRightShiftNode extends Node {
     @Override
     public int hashCode() {
         return HashCodeUtils.hash(getLeftOperand(), getRightOperand());
-    }
-
-    @Override
-    public Collection<Node> getOperands() {
-        LinkedList<Node> list = new LinkedList<Node>();
-        list.add(getLeftOperand());
-        list.add(getRightOperand());
-        return list;
     }
 }


### PR DESCRIPTION
Add abstract classes `UnaryOperation` and `BinaryOperation` to categorize operations Node types into `UnaryOperation` and `BinaryOperation`.

This could reduce code duplication in dataflow-framework, and also could enable us to have conciser code expression when developing dataflow analysis.
