### PR TITLE
Move javac.jar dependency from bootclasspath to normal classpath.

### DIFF
--- a/checker/bin-devel/javac
+++ b/checker/bin-devel/javac
@@ -63,7 +63,7 @@ eval "java" \
      "-DCheckerDevelMain.cp=${buildDirs} " \
      "-DCheckerDevelMain.pp=${buildDirs} " \
      "-DCheckerDevelMain.compile.bcp=${jdkPaths} " \
-     "-DCheckerDevelMain.runtime.bcp=${ltBinDir} " \
+     "-DCheckerDevelMain.runtime.cp=${ltBinDir} " \
      "-DCheckerDevelMain.binary=${binaryDir}" \
      "-classpath ${buildDirs} " \
      "org.checkerframework.framework.util.CheckerDevelMain" \

--- a/checker/build.xml
+++ b/checker/build.xml
@@ -212,7 +212,6 @@
               failonerror="true"
               classpath="${javac.lib}:${framework.lib}:${javaparser.core.lib}:${junit.lib}:${hamcrest.lib}:${annotation-file-utilities.lib}"
               classname="com.sun.tools.javac.Main">
-            <jvmarg value="-Xbootclasspath/p:${javac.lib}"/>
             <arg value="-g"/>
             <!-- Make sure we only have Java 8 source code and generate Java 8 bytecode. -->
             <arg value="-source"/>
@@ -271,7 +270,7 @@
                  executable="${javadoc.bin}"
                  classpath="${build}:${javac.lib}:${javadoc.lib}:${junit.lib}:${hamcrest.lib}:${annotation-file-utilities.lib}"
                  excludepackagenames="org.checkerframework.framework.stub"
-                 bootclasspath="${javac.lib}:${javadoc.lib}:${java.home}/lib/rt.jar">
+                 bootclasspath="${java.home}/lib/rt.jar">
 
             <package name="org.checkerframework.javacutil.*"/>
             <package name="org.checkerframework.dataflow.*"/>
@@ -389,8 +388,8 @@
         <echo message="Compiling qualifiers."/>
         <java fork="true"
               failonerror="true"
-              classname="com.sun.tools.javac.Main">
-            <jvmarg value="-Xbootclasspath/p:${javac.lib}"/>
+              classname="com.sun.tools.javac.Main"
+              classpath="${javac.lib}">
             <arg value="-g"/>
             <!-- Make sure we only have Java 7 source code and generate Java 7 bytecode. -->
             <arg value="-source"/>
@@ -434,8 +433,7 @@
         <java fork="true"
               failonerror="true"
               classname="com.sun.tools.javac.Main"
-              classpath="${checker-qual-classes-tmp}">
-            <jvmarg value="-Xbootclasspath/p:${javac.lib}"/>
+              classpath="${javac.lib}:${checker-qual-classes-tmp}">
             <arg value="-g"/>
             <arg value="-source"/>
             <arg value="8"/>
@@ -510,8 +508,8 @@
         <echo message="${compat.qual.src.files.spaceseparated}" file="${tmpdir}/srcfiles-checker.txt"/>
         <java fork="true"
               failonerror="true"
-              classname="com.sun.tools.javac.Main">
-            <jvmarg value="-Xbootclasspath/p:${javac.lib}"/>
+              classname="com.sun.tools.javac.Main"
+              classpath="${javac.lib}">
             <arg value="-g"/>
             <!-- Make sure we only generate Java 6 bytecode. -->
             <arg value="-source"/>
@@ -563,7 +561,6 @@
               failonerror="true"
               classpath="${build}:${javac.lib}:${junit.lib}:${hamcrest.lib}"
               classname="com.sun.tools.javac.Main">
-            <jvmarg value="-Xbootclasspath/p:${javac.lib}"/>
             <arg value="-g"/>
             <arg value="-source"/>
             <arg value="8"/>
@@ -623,7 +620,6 @@
 
             <!-- plain output for debugging -->
 
-            <jvmarg value="-Xbootclasspath/p:${javac.lib}"/>
             <jvmarg line="${debugger.str}"/> <!-- may be empty string -->
 
             <sysproperty key="JDK_JAR" value="${basedir}/dist/${jdkName}"/>
@@ -687,7 +683,6 @@
                printsummary="false"
                haltonerror="${halt.on.test.failure}"
                haltonfailure="${halt.on.test.failure}">
-            <jvmarg value="-Xbootclasspath/p:${javac.lib}"/>
             <jvmarg value="-ea"/>
             <jvmarg line="${debugger.str}"/>  <!-- may be empty string -->
             <sysproperty key="JDK_JAR" value="${basedir}/dist/${jdkName}"/>
@@ -1266,7 +1261,6 @@ So, use our own archived version.
               failonerror="true"
               classpath="${build}:${javac.lib}:${checker.lib}:${framework.lib}:${junit.lib}:${hamcrest.lib}:${annotation-file-utilities.lib}"
               classname="com.sun.tools.javac.Main">
-            <jvmarg value="-Xbootclasspath/p:${javac.lib}"/>
             <jvmarg line="${maybeDebug}"/>  <!-- may be empty string -->
             <arg value="-g"/>
             <arg value="-encoding"/>

--- a/checker/build.xml
+++ b/checker/build.xml
@@ -682,8 +682,6 @@
                printsummary="false"
                haltonerror="${halt.on.test.failure}"
                haltonfailure="${halt.on.test.failure}">
-            <!-- TODO: Figure out why we need javac.lib on bootclasspath when running test. -->
-            <jvmarg value="-Xbootclasspath/p:${javac.lib}"/>
             <jvmarg value="-ea"/>
             <jvmarg line="${debugger.str}"/>  <!-- may be empty string -->
             <sysproperty key="JDK_JAR" value="${basedir}/dist/${jdkName}"/>

--- a/checker/build.xml
+++ b/checker/build.xml
@@ -269,8 +269,7 @@
                  failonerror="true"
                  executable="${javadoc.bin}"
                  classpath="${build}:${javac.lib}:${javadoc.lib}:${junit.lib}:${hamcrest.lib}:${annotation-file-utilities.lib}"
-                 excludepackagenames="org.checkerframework.framework.stub"
-                 bootclasspath="${java.home}/lib/rt.jar">
+                 excludepackagenames="org.checkerframework.framework.stub">
 
             <package name="org.checkerframework.javacutil.*"/>
             <package name="org.checkerframework.dataflow.*"/>

--- a/checker/build.xml
+++ b/checker/build.xml
@@ -682,6 +682,8 @@
                printsummary="false"
                haltonerror="${halt.on.test.failure}"
                haltonfailure="${halt.on.test.failure}">
+            <!-- TODO: Figure out why we need javac.lib on bootclasspath when running test. -->
+            <jvmarg value="-Xbootclasspath/p:${javac.lib}"/>
             <jvmarg value="-ea"/>
             <jvmarg line="${debugger.str}"/>  <!-- may be empty string -->
             <sysproperty key="JDK_JAR" value="${basedir}/dist/${jdkName}"/>

--- a/dataflow/build.xml
+++ b/dataflow/build.xml
@@ -161,8 +161,7 @@
                  additionalParam="-Xdoclint:all,-missing"
                  failonerror="true"
                  executable="${javadoc.bin}"
-                 classpath="${build}:${javacutil.lib}:${javac.lib}:${javadoc.lib}:${java.home}/../lib/tools.jar"
-                 bootclasspath="${java.home}/lib/rt.jar">
+                 classpath="${build}:${javacutil.lib}:${javac.lib}:${javadoc.lib}:${java.home}/../lib/tools.jar">
             <package name="org.checkerframework.dataflow.*"/>
             <package name="org.checkerframework.javacutil.*"/>
             <link href="http://docs.oracle.com/javase/8/docs/api/"/>

--- a/dataflow/build.xml
+++ b/dataflow/build.xml
@@ -96,7 +96,6 @@
               failonerror="true"
               classpath="${javac.lib}:${javacutil.lib}"
               classname="com.sun.tools.javac.Main">
-            <jvmarg value="-Xbootclasspath/p:${javac.lib}"/>
             <arg value="-g"/>
             <!-- Make sure we only have Java 7 source code and generate Java 7 bytecode. -->
             <arg value="-source"/>
@@ -163,7 +162,7 @@
                  failonerror="true"
                  executable="${javadoc.bin}"
                  classpath="${build}:${javacutil.lib}:${javac.lib}:${javadoc.lib}:${java.home}/../lib/tools.jar"
-                 bootclasspath="${javac.lib}:${javadoc.lib}:${java.home}/lib/rt.jar">
+                 bootclasspath="${java.home}/lib/rt.jar">
             <package name="org.checkerframework.dataflow.*"/>
             <package name="org.checkerframework.javacutil.*"/>
             <link href="http://docs.oracle.com/javase/8/docs/api/"/>

--- a/docs/examples/GradleExamples/GradleJava7Example/build.gradle
+++ b/docs/examples/GradleExamples/GradleJava7Example/build.gradle
@@ -15,11 +15,6 @@ repositories {
 
 
 configurations {
-    if (targetJavaVersion.isJava7()) {
-        checkerFrameworkJavac {
-            description = 'a customization of the Open JDK javac compiler with additional support for type annotations'
-        }
-    }
     checkerFrameworkAnnotatedJDK {
        description = 'a copy of JDK classes with Checker Framework type qualifers inserted'
     }
@@ -53,10 +48,5 @@ allprojects {
                 //'-Awarns',
                 "-Xbootclasspath/p:${configurations.checkerFrameworkAnnotatedJDK.asPath}"
         ]
-        if (targetJavaVersion.isJava7()) {
-            compile.options.compilerArgs += ['-source', '7', '-target', '7']
-            options.fork = true
-            options.forkOptions.jvmArgs += ["-Xbootclasspath/p:${configurations.checkerFrameworkJavac.asPath}"]
-        }
     }
 }

--- a/docs/examples/MavenExample/pom.xml
+++ b/docs/examples/MavenExample/pom.xml
@@ -96,8 +96,7 @@
                   <arg>-Xbootclasspath/p:${annotatedJdk}</arg>
                   <!--treat Checker Framework errors as warnings-->
                   <!-- <arg>-Awarns</arg> -->
-                  <!-- Uncomment the following line if using Java 7. -->
-                  <!--<arg>-J-Xbootclasspath/p:${typeAnnotationsJavac}</arg>-->
+                  <arg>-classpath ${typeAnnotationsJavac}</arg>
                   <arg>-Alint</arg>
               </compilerArgs>
           </configuration>

--- a/docs/manual/external-tools.tex
+++ b/docs/manual/external-tools.tex
@@ -484,7 +484,7 @@ For example, to use the \code{org.checkerframework.checker.nullness.NullnessChec
         <!-- location of the annotated JDK, which comes from a Maven dependency -->
         <arg>-Xbootclasspath/p:$\{annotatedJdk\}</arg>
         <!-- Uncomment the following line to use the type annotations compiler. -->
-        <!-- <arg>-J-Xbootclasspath/p:$\{typeAnnotationsJavac\}</arg> -->
+        <!-- <arg>-classpath $\{typeAnnotationsJavac\}</arg> -->
       </compilerArgs>
     </configuration>
   </plugin>
@@ -591,11 +591,6 @@ allprojects {
                 // '-Awarns', '-Xmaxwarns', '10000',
                 "-Xbootclasspath/p:${configurations.checkerFrameworkAnnotatedJDK.asPath}"
         ]
-        if (targetJavaVersion.isJava7()) {
-            compile.options.compilerArgs += ['-source', '7', '-target', '7']
-            options.fork = true
-            options.forkOptions.jvmArgs += ["-Xbootclasspath/p:${configurations.checkerFrameworkJavac.asPath}"]
-        }
     }
 }
 \end{Verbatim}

--- a/framework/build.xml
+++ b/framework/build.xml
@@ -144,7 +144,6 @@
               failonerror="true"
               classpath="${javac.lib}:${javacutil.lib}:${dataflow.lib}:${javaparser.core.lib}:${junit.lib}:${hamcrest.lib}:${annotation-file-utilities.lib}"
               classname="com.sun.tools.javac.Main">
-            <jvmarg value="-Xbootclasspath/p:${javac.lib}"/>
             <arg value="-g"/>
             <!-- Make sure we only have Java 7 source code and generate Java 7 bytecode. -->
             <arg value="-source"/>
@@ -203,7 +202,7 @@
                  executable="${javadoc.bin}"
                  classpath="${build}:${javac.lib}:${javacutil.lib}:${dataflow.lib}:${javadoc.lib}:${junit.lib}:${hamcrest.lib}:${annotation-file-utilities.lib}"
                  excludepackagenames="org.checkerframework.framework.stub"
-                 bootclasspath="${javac.lib}:${javadoc.lib}:${java.home}/lib/rt.jar">
+                 bootclasspath="${java.home}/lib/rt.jar">
             <package name="org.checkerframework.javacutil.*"/>
             <package name="org.checkerframework.dataflow.*"/>
             <package name="org.checkerframework.framework.*"/>
@@ -258,7 +257,6 @@
               failonerror="true"
               classpath="${javac.lib}:${build}:${javacutil.lib}:${dataflow.lib}:${javaparser.core.lib}:${junit.lib}:${hamcrest.lib}:${annotation-file-utilities.lib}"
               classname="com.sun.tools.javac.Main">
-            <jvmarg value="-Xbootclasspath/p:${javac.lib}"/>
             <arg value="-g"/>
             <!-- Make sure we only have Java 7 source code and generate Java 7 bytecode. -->
             <arg value="-source"/>
@@ -287,7 +285,6 @@
                printsummary="false"
                haltonerror="${halt.on.test.failure}"
                haltonfailure="${halt.on.test.failure}">
-            <jvmarg value="-Xbootclasspath/p:${javac.lib}"/>
             <jvmarg value="-ea"/>
             <jvmarg value="-Dorg.checkerframework.common.reflection.debug=false"/>
 
@@ -335,7 +332,6 @@
              haltonerror="${halt.on.test.failure}"
              haltonfailure="${halt.on.test.failure}"
              showoutput="true">
-          <jvmarg value="-Xbootclasspath/p:${javac.lib}"/>
           <jvmarg value="-ea"/>
 
           <classpath>
@@ -745,7 +741,6 @@
               failonerror="true"
               classpath="${javac.lib}:${framework.lib}:${junit.lib}:${hamcrest.lib}:${annotation-file-utilities.lib}"
               classname="com.sun.tools.javac.Main">
-            <jvmarg value="-Xbootclasspath/p:${javac.lib}"/>
             <arg value="-g"/>
             <!-- Make sure we only have Java 7 source code and generate Java 7 bytecode. -->
             <arg value="-source"/>

--- a/framework/build.xml
+++ b/framework/build.xml
@@ -201,8 +201,7 @@
                  failonerror="true"
                  executable="${javadoc.bin}"
                  classpath="${build}:${javac.lib}:${javacutil.lib}:${dataflow.lib}:${javadoc.lib}:${junit.lib}:${hamcrest.lib}:${annotation-file-utilities.lib}"
-                 excludepackagenames="org.checkerframework.framework.stub"
-                 bootclasspath="${java.home}/lib/rt.jar">
+                 excludepackagenames="org.checkerframework.framework.stub">
             <package name="org.checkerframework.javacutil.*"/>
             <package name="org.checkerframework.dataflow.*"/>
             <package name="org.checkerframework.framework.*"/>

--- a/framework/src/org/checkerframework/framework/util/CheckerDevelMain.java
+++ b/framework/src/org/checkerframework/framework/util/CheckerDevelMain.java
@@ -12,14 +12,14 @@ public class CheckerDevelMain extends CheckerMain {
     private static final String CP_PROP = PROP_PREFIX + ".cp";
     private static final String PP_PROP = PROP_PREFIX + ".pp";
     private static final String COMPILE_BCP_PROP = PROP_PREFIX + ".compile.bcp";
-    private static final String RUNTIME_BCP_PROP = PROP_PREFIX + ".runtime.bcp";
+    private static final String RUNTIME_CP_PROP = PROP_PREFIX + ".runtime.cp";
     private static final String VERBOSE_PROP = PROP_PREFIX + ".verbose";
 
     public static void main(final String[] args) {
 
         final String cp = System.getProperty(CP_PROP);
         final String pp = System.getProperty(PP_PROP);
-        final String runtimeBcp = System.getProperty(RUNTIME_BCP_PROP);
+        final String runtimeCp = System.getProperty(RUNTIME_CP_PROP);
         final String compileBcp = System.getProperty(COMPILE_BCP_PROP);
         final String binDir = System.getProperty(BINARY_PROP);
         final String verbose = System.getProperty(VERBOSE_PROP);
@@ -35,8 +35,8 @@ public class CheckerDevelMain extends CheckerMain {
                             + "Prepended to compile bootclasspath: "
                             + compileBcp
                             + "\n"
-                            + "Prepended to runtime bootclasspath: "
-                            + runtimeBcp
+                            + "Prepended to runtime classpath: "
+                            + runtimeCp
                             + "\n"
                             + "Binary Dir:                 "
                             + binDir
@@ -52,9 +52,9 @@ public class CheckerDevelMain extends CheckerMain {
         assert (pp != null)
                 : PP_PROP + " must specify a path entry to prepend to the processor path";
 
-        assert (runtimeBcp != null)
-                : RUNTIME_BCP_PROP
-                        + " must specify a path entry to prepend to the Java bootclasspath when running Javac"; //TODO: Fix the assert messages
+        assert (runtimeCp != null)
+                : RUNTIME_CP_PROP
+                        + " must specify a path entry to prepend to the Java classpath when running Javac"; //TODO: Fix the assert messages
         assert (compileBcp != null)
                 : COMPILE_BCP_PROP
                         + " must specify a path entry to prepend to the compiler bootclasspath";
@@ -81,8 +81,8 @@ public class CheckerDevelMain extends CheckerMain {
     public void assertValidState() {}
 
     @Override
-    protected List<String> createRuntimeBootclasspath(final List<String> argsList) {
-        return prependPathOpts(RUNTIME_BCP_PROP, new ArrayList<String>());
+    protected List<String> createRuntimeClasspath(final List<String> argsList) {
+        return prependPathOpts(RUNTIME_CP_PROP, new ArrayList<String>());
     }
 
     @Override

--- a/framework/src/org/checkerframework/framework/util/CheckerMain.java
+++ b/framework/src/org/checkerframework/framework/util/CheckerMain.java
@@ -72,7 +72,7 @@ public class CheckerMain {
 
     private final List<String> compilationBootclasspath;
 
-    private final List<String> runtimeBootClasspath;
+    private final List<String> runtimeClasspath;
 
     private final List<String> jvmOpts;
 
@@ -105,7 +105,7 @@ public class CheckerMain {
                 extractFileArg(PluginUtil.JDK_PATH_OPT, new File(searchPath, jdkJarName), args);
 
         this.compilationBootclasspath = createCompilationBootclasspath(args);
-        this.runtimeBootClasspath = createRuntimeBootclasspath(args);
+        this.runtimeClasspath = createRuntimeClasspath(args);
         this.jvmOpts = extractJvmOpts(args);
 
         this.cpOpts = createCpOpts(args);
@@ -127,11 +127,11 @@ public class CheckerMain {
         this.ppOpts.addAll(ppOpts);
     }
 
-    public void addToRuntimeBootclasspath(List<String> runtimeBootClasspathOpts) {
-        this.runtimeBootClasspath.addAll(runtimeBootClasspathOpts);
+    public void addToRuntimeClasspath(List<String> runtimeClasspathOpts) {
+        this.runtimeClasspath.addAll(runtimeClasspathOpts);
     }
 
-    protected List<String> createRuntimeBootclasspath(final List<String> argsList) {
+    protected List<String> createRuntimeClasspath(final List<String> argsList) {
         return new ArrayList<String>(Arrays.asList(javacJar.getAbsolutePath()));
     }
 
@@ -375,7 +375,8 @@ public class CheckerMain {
 
         // Prepend ("/p:") because our javac.jar doesn't have all classes
         // required by the Java runtime to execute the compiler.
-        args.add("-Xbootclasspath/p:" + PluginUtil.join(File.pathSeparator, runtimeBootClasspath));
+        args.add("-classpath");
+        args.add(PluginUtil.join(File.pathSeparator, runtimeClasspath));
         args.add("-ea");
         // com.sun.tools needs to be enabled separately
         args.add("-ea:com.sun.tools...");

--- a/framework/src/org/checkerframework/framework/util/CheckerMain.java
+++ b/framework/src/org/checkerframework/framework/util/CheckerMain.java
@@ -373,8 +373,6 @@ public class CheckerMain {
         final String java = PluginUtil.getJavaCommand(System.getProperty("java.home"), System.out);
         args.add(java);
 
-        // Prepend ("/p:") because our javac.jar doesn't have all classes
-        // required by the Java runtime to execute the compiler.
         args.add("-classpath");
         args.add(PluginUtil.join(File.pathSeparator, runtimeClasspath));
         args.add("-ea");

--- a/framework/tests/all-systems/java8/memberref/MemberReferences.java
+++ b/framework/tests/all-systems/java8/memberref/MemberReferences.java
@@ -31,7 +31,7 @@ class Super {
         void context() {
             FunctionMR<Object, Object> f1 = super::func1;
             // TODO: Issue 802: type argument inference
-            //:: warning: (methodref.inference.unimplemented)
+            // TODO: should expect warning: (methodref.inference.unimplemented)
             FunctionMR f2 = super::func2;
             // Top level wildcards are ignored when type checking
             FunctionMR<? extends String, ? extends String> f3 = super::<String>func2;


### PR DESCRIPTION
As CheckerFramework decide to not support java 7 anymore, so it would be good to move jsr308 javac.jar from bootclasspath to normal classpath.

Reason of this moving: Originally put javac.jar on bootclasspath is mainly to be able compile CF under java 7 by overriding normal compiler with jsr308 compiler. Since we don't support java 7 anymore, move javac.jar to normal classpath would be better --- we will only have annotated JDK on the bootclasspath, all other dependencies would be placed on normal classpath.

Changes include in this PR:

- Ant build files: move javac.jar from bootclasspath to classpath for several compilation targets.
- CheckerMain and CheckerDevelMain: move javac.jar to classpath when launching CF.
