### PR TITLE
Use protected method to validate Annotation Set in CFAbsValue constructor

### DIFF
--- a/framework/src/org/checkerframework/framework/flow/CFAbstractValue.java
+++ b/framework/src/org/checkerframework/framework/flow/CFAbstractValue.java
@@ -76,14 +76,14 @@ public abstract class CFAbstractValue<V extends CFAbstractValue<V>> implements A
 
     protected void annotationsValidation() {
         if (!validateSet(
-                        this.getAnnotations(),
-                        this.getUnderlyingType(),
-                        analysis.getTypeFactory().getQualifierHierarchy())) {
+                this.getAnnotations(),
+                this.getUnderlyingType(),
+                analysis.getTypeFactory().getQualifierHierarchy())) {
             ErrorReporter.errorAbort(
                     "Encountered invalid type: "
-                        + underlyingType
-                        + " annotations: "
-                        + PluginUtil.join(", ", annotations));
+                            + underlyingType
+                            + " annotations: "
+                            + PluginUtil.join(", ", annotations));
         }
     }
 


### PR DESCRIPTION
Use a protected method instead of an assertion against on a static method to validate annotation set in `CFAbsValue` constructor, so that sub-classes may customize their own validation logic.

The underlying motivation of this change is `InferenceValue` in CFI project has special cases that need to by-pass this validation, i.e. this annotation set validation is not always true in `InferenceValue`.

For example, in `InferenceAnalysis`, when we calculate the LUB of two `InferenceValue` which all represent constant slots, the computed LUB would only contains an annotation from the `realQualifierHierarchy`, without a `VarAnno` (as this one is computed during dataflow analysis, not some AST location visited by `VarAnnotator`), see [implementation of `inferenceValue#LUB()` here](https://github.com/opprop/checker-framework-inference/blob/master/src/checkers/inference/dataflow/InferenceValue.java#L66). In this case, it make sense to create an `InferenceValue` that contains only this real annotation without a `varAnno`. However, currently the assertion in the parent class `CFAbsValue` prevent this kind of creation, as the real annotation doesn't belongs to the `InferenceQualHierarchy`.

The travis test is expected to be failed, as this change always enable validation in `CFAbsValue`, which cause the downstream test failed on CFI.
