### PR TITLE
Only replace annotation on the missing bound for wildcard when fixing bound annotations

### DIFF
--- a/framework/src/org/checkerframework/framework/type/AnnotatedTypeMirror.java
+++ b/framework/src/org/checkerframework/framework/type/AnnotatedTypeMirror.java
@@ -1960,12 +1960,34 @@ public abstract class AnnotatedTypeMirror {
 
         private void fixupBoundAnnotations() {
             if (!this.getAnnotationsField().isEmpty()) {
-                if (superBound != null) {
-                    superBound.replaceAnnotations(this.getAnnotationsField());
+
+                WildcardType underlyingType = this.getUnderlyingType();
+                if (underlyingType.getExtendsBound() == null
+                        && underlyingType.getSuperBound() == null) {
+                    // Unbound wildcard
+                    replaceAnnoOnExtend();
+                    replaceAnnoOnSuper();
+
+                } else if (underlyingType.getSuperBound() == null) {
+                    // Extend bound wildcard
+                    replaceAnnoOnSuper();
+
+                } else {
+                    // Super bound wildcard
+                    replaceAnnoOnExtend();
                 }
-                if (extendsBound != null) {
-                    extendsBound.replaceAnnotations(this.getAnnotationsField());
-                }
+            }
+        }
+
+        private void replaceAnnoOnSuper() {
+            if (superBound != null) {
+                superBound.replaceAnnotations(this.getAnnotationsField());
+            }
+        }
+
+        private void replaceAnnoOnExtend() {
+            if (extendsBound != null) {
+                extendsBound.replaceAnnotations(this.getAnnotationsField());
             }
         }
 

--- a/framework/src/org/checkerframework/framework/type/TypeVariableSubstitutor.java
+++ b/framework/src/org/checkerframework/framework/type/TypeVariableSubstitutor.java
@@ -12,6 +12,7 @@ import javax.lang.model.type.TypeVariable;
 import javax.lang.model.util.Types;
 import org.checkerframework.framework.type.AnnotatedTypeMirror.AnnotatedArrayType;
 import org.checkerframework.framework.type.AnnotatedTypeMirror.AnnotatedTypeVariable;
+import org.checkerframework.framework.type.AnnotatedTypeMirror.AnnotatedWildcardType;
 
 /** TypeVariableSusbtitutor replaces type variables from a declaration with arguments to its use. */
 public class TypeVariableSubstitutor {
@@ -51,6 +52,11 @@ public class TypeVariableSubstitutor {
 
         if (!use.getAnnotationsField().isEmpty()) {
             substitute.replaceAnnotations(use.getAnnotations());
+            if (substitute.getKind() == TypeKind.WILDCARD) {
+                AnnotatedWildcardType substituteWildcard = (AnnotatedWildcardType) substitute;
+                substituteWildcard.getExtendsBound().replaceAnnotations(use.getAnnotations());
+                substituteWildcard.getSuperBound().replaceAnnotations(use.getAnnotations());
+            }
         }
 
         return substitute;

--- a/framework/src/org/checkerframework/framework/type/TypeVariableSubstitutor.java
+++ b/framework/src/org/checkerframework/framework/type/TypeVariableSubstitutor.java
@@ -50,6 +50,12 @@ public class TypeVariableSubstitutor {
         final AnnotatedTypeMirror substitute = argument.shallowCopy(false);
         substitute.addAnnotations(argument.getAnnotationsField());
 
+        if (substitute.getKind() == TypeKind.WILDCARD) {
+            AnnotatedWildcardType substituteWildcard = (AnnotatedWildcardType) substitute;
+            substituteWildcard.getExtendsBound().replaceAnnotations(argument.getAnnotations());
+            substituteWildcard.getSuperBound().replaceAnnotations(argument.getAnnotations());
+        }
+
         if (!use.getAnnotationsField().isEmpty()) {
             substitute.replaceAnnotations(use.getAnnotations());
             if (substitute.getKind() == TypeKind.WILDCARD) {


### PR DESCRIPTION
According to [CF manual section 23.1.4](https://checkerframework.org/manual/#generics) about annotations on wildcards, we assume the annotation in front of the wildcard type itself represent the annotation on the missing bound.

However, when calling `WildcardType#addAnnotation(am)`, inside the method implementation in `WildcardType`, it will call `fixupBoundAnnotations()` at the end, which would replace both annotations on super bound and extend bound to the same annotation on the wildcard type itself.

This seems rather strange --- suppose I have an annotation `@Var(1)` on a wildcard type `? extends @Var(1) Object`, now I want to add `@Var(2)` to wildcard type itself to representing the missing super bound. By calling this method, it actually gives me: `@Var(2) ? extends @Var(2) Object`, as it will replace both annotations on super bound and extend bound by this newly added annotation.

I don't think this really makes sense. So in this PR I removed this `fixupBoundAnnotations()` call in `WildcardType#addAnnotation()`.

P.S. I cannot see the motivation of this method call in original implementation, so let's see if this removal breaks any existed test.
