### PR TITLE
Make QualifierDefault extendable.

### DIFF
--- a/framework/src/org/checkerframework/framework/type/GenericAnnotatedTypeFactory.java
+++ b/framework/src/org/checkerframework/framework/type/GenericAnnotatedTypeFactory.java
@@ -226,7 +226,7 @@ public abstract class GenericAnnotatedTypeFactory<
         super.postInit();
 
         this.dependentTypesHelper = createDependentTypesHelper();
-        this.defaults = createQualifierDefaults();
+        this.defaults = createAndInitQualifierDefaults();
         this.treeAnnotator = createTreeAnnotator();
         this.typeAnnotator = createTypeAnnotator();
 
@@ -497,8 +497,8 @@ public abstract class GenericAnnotatedTypeFactory<
     // Both methods should have some functionality merged into a single location.
     // See Issue 683
     // https://github.com/typetools/checker-framework/issues/683
-    protected final QualifierDefaults createQualifierDefaults() {
-        QualifierDefaults defs = new QualifierDefaults(elements, this);
+    protected final QualifierDefaults createAndInitQualifierDefaults() {
+        QualifierDefaults defs = createQualifierDefaults();
         addCheckedCodeDefaults(defs);
         addCheckedStandardDefaults(defs);
         addUncheckedCodeDefaults(defs);
@@ -506,6 +506,10 @@ public abstract class GenericAnnotatedTypeFactory<
         checkForDefaultQualifierInHierarchy(defs);
 
         return defs;
+    }
+
+    protected QualifierDefaults createQualifierDefaults() {
+        return new QualifierDefaults(elements, this);
     }
 
     /** Defines alphabetical sort ordering for qualifiers */

--- a/framework/src/org/checkerframework/framework/util/defaults/Default.java
+++ b/framework/src/org/checkerframework/framework/util/defaults/Default.java
@@ -11,7 +11,7 @@ import org.checkerframework.javacutil.AnnotationUtils;
  *
  * <p>It also has a handy toString method that is useful for debugging.
  */
-class Default implements Comparable<Default> {
+public class Default implements Comparable<Default> {
     // please remember to add any fields to the hashcode calculation
     public final AnnotationMirror anno;
     public final TypeUseLocation location;

--- a/framework/src/org/checkerframework/framework/util/defaults/QualifierDefaults.java
+++ b/framework/src/org/checkerframework/framework/util/defaults/QualifierDefaults.java
@@ -724,10 +724,10 @@ public class QualifierDefaults {
         return new DefaultApplierElement(atypeFactory, annotationScope, type, applyToTypeVar);
     }
 
-    public class DefaultApplierElement {
+    public static class DefaultApplierElement {
 
-        private final AnnotatedTypeFactory atypeFactory;
-        private final Element scope;
+        protected final AnnotatedTypeFactory atypeFactory;
+        protected final Element scope;
         protected final AnnotatedTypeMirror type;
 
         /**

--- a/framework/src/org/checkerframework/framework/util/defaults/QualifierDefaults.java
+++ b/framework/src/org/checkerframework/framework/util/defaults/QualifierDefaults.java
@@ -699,7 +699,7 @@ public class QualifierDefaults {
             final Element annotationScope, final AnnotatedTypeMirror type) {
         DefaultSet defaults = defaultsAt(annotationScope);
         DefaultApplierElement applier =
-                new DefaultApplierElement(atypeFactory, annotationScope, type, applyToTypeVar);
+                createDefaultApplierElement(atypeFactory, annotationScope, type, applyToTypeVar);
 
         for (Default def : defaults) {
             applier.applyDefault(def);
@@ -716,18 +716,26 @@ public class QualifierDefaults {
         }
     }
 
-    public static class DefaultApplierElement {
+    protected DefaultApplierElement createDefaultApplierElement(
+            AnnotatedTypeFactory atypeFactory,
+            Element annotationScope,
+            AnnotatedTypeMirror type,
+            boolean applyToTypeVar) {
+        return new DefaultApplierElement(atypeFactory, annotationScope, type, applyToTypeVar);
+    }
+
+    public class DefaultApplierElement {
 
         private final AnnotatedTypeFactory atypeFactory;
         private final Element scope;
-        private final AnnotatedTypeMirror type;
+        protected final AnnotatedTypeMirror type;
 
         /**
          * Location to which to apply the default. (Should only be set by the applyDefault method.)
          */
-        private TypeUseLocation location;
+        protected TypeUseLocation location;
 
-        private final DefaultApplierElementImpl impl;
+        protected final DefaultApplierElementImpl impl;
 
         /*Local type variables are defaulted to top when flow is turned on
           We only want to default the top level type variable (and not type variables that are nested
@@ -770,7 +778,7 @@ public class QualifierDefaults {
          * @param type type to which qual would be applied
          * @return true if this application should proceed
          */
-        private static boolean shouldBeAnnotated(
+        protected boolean shouldBeAnnotated(
                 final AnnotatedTypeMirror type, final boolean applyToTypeVar) {
 
             return !(type == null
@@ -790,7 +798,7 @@ public class QualifierDefaults {
          * @param type type to add qual
          * @param qual annotation to add
          */
-        private static void addAnnotation(AnnotatedTypeMirror type, AnnotationMirror qual) {
+        protected void addAnnotation(AnnotatedTypeMirror type, AnnotationMirror qual) {
             // Add the default annotation, but only if no other
             // annotation is present.
             if (!type.isAnnotatedInHierarchy(qual) && type.getKind() != TypeKind.EXECUTABLE) {
@@ -813,7 +821,7 @@ public class QualifierDefaults {
             }
         }
 
-        private class DefaultApplierElementImpl
+        protected class DefaultApplierElementImpl
                 extends AnnotatedTypeScanner<Void, AnnotationMirror> {
 
             @Override


### PR DESCRIPTION
Make `QualifierDefault` extendable, so that CF Inference could extend this base class and have an `InferenceQualifierDefault` for applying defaults in inference mode.

PR for implementing inference defaulting: https://github.com/opprop/checker-framework-inference/pull/134