### PR TITLE
Use the qualHier to get top and btm in QualDefault.

### DIFF
--- a/framework/src/org/checkerframework/framework/type/GenericAnnotatedTypeFactory.java
+++ b/framework/src/org/checkerframework/framework/type/GenericAnnotatedTypeFactory.java
@@ -603,9 +603,7 @@ public abstract class GenericAnnotatedTypeFactory<
      */
     protected void addCheckedStandardDefaults(QualifierDefaults defs) {
         if (this.everUseFlow) {
-            Set<? extends AnnotationMirror> tops = this.qualHierarchy.getTopAnnotations();
-            Set<? extends AnnotationMirror> bottoms = this.qualHierarchy.getBottomAnnotations();
-            defs.addClimbStandardDefaults(tops, bottoms);
+            defs.addClimbStandardDefaults();
         }
     }
 
@@ -655,9 +653,7 @@ public abstract class GenericAnnotatedTypeFactory<
      * @param defs {@link QualifierDefaults} object to which defaults are added
      */
     protected void addUncheckedStandardDefaults(QualifierDefaults defs) {
-        Set<? extends AnnotationMirror> tops = this.qualHierarchy.getTopAnnotations();
-        Set<? extends AnnotationMirror> bottoms = this.qualHierarchy.getBottomAnnotations();
-        defs.addUncheckedStandardDefaults(tops, bottoms);
+        defs.addUncheckedStandardDefaults();
     }
 
     /**

--- a/framework/src/org/checkerframework/framework/util/defaults/QualifierDefaults.java
+++ b/framework/src/org/checkerframework/framework/util/defaults/QualifierDefaults.java
@@ -202,12 +202,7 @@ public class QualifierDefaults {
         return false;
     }
 
-    /**
-     * Add standard unchecked defaults that do not conflict with previously added defaults.
-     *
-     * @param tops AnnotationMirrors that are top
-     * @param bottoms AnnotationMirrors that are bottom
-     */
+    /** Add standard unchecked defaults that do not conflict with previously added defaults. */
     public void addUncheckedStandardDefaults() {
         for (TypeUseLocation loc : standardUncheckedDefaultsTop) {
             // Only add standard defaults in locations where a default has not be specified
@@ -229,12 +224,7 @@ public class QualifierDefaults {
         }
     }
 
-    /**
-     * Add standard CLIMB defaults that do not conflict with previously added defaults.
-     *
-     * @param tops AnnotationMirrors that are top
-     * @param bottoms AnnotationMirrors that are bottom
-     */
+    /** Add standard CLIMB defaults that do not conflict with previously added defaults. */
     public void addClimbStandardDefaults() {
         QualifierHierarchy qualHierarchy = this.atypeFactory.getQualifierHierarchy();
         Set<? extends AnnotationMirror> tops = qualHierarchy.getTopAnnotations();

--- a/framework/src/org/checkerframework/framework/util/defaults/QualifierDefaults.java
+++ b/framework/src/org/checkerframework/framework/util/defaults/QualifierDefaults.java
@@ -208,12 +208,10 @@ public class QualifierDefaults {
      * @param tops AnnotationMirrors that are top
      * @param bottoms AnnotationMirrors that are bottom
      */
-    public void addUncheckedStandardDefaults(
-            Iterable<? extends AnnotationMirror> tops,
-            Iterable<? extends AnnotationMirror> bottoms) {
+    public void addUncheckedStandardDefaults() {
         for (TypeUseLocation loc : standardUncheckedDefaultsTop) {
             // Only add standard defaults in locations where a default has not be specified
-            for (AnnotationMirror top : tops) {
+            for (AnnotationMirror top : atypeFactory.getQualifierHierarchy().getTopAnnotations()) {
                 if (!conflictsWithExistingDefaults(uncheckedCodeDefaults, top, loc)) {
                     addUncheckedCodeDefault(top, loc);
                 }
@@ -221,7 +219,8 @@ public class QualifierDefaults {
         }
 
         for (TypeUseLocation loc : standardUncheckedDefaultsBottom) {
-            for (AnnotationMirror bottom : bottoms) {
+            for (AnnotationMirror bottom :
+                    atypeFactory.getQualifierHierarchy().getBottomAnnotations()) {
                 // Only add standard defaults in locations where a default has not be specified
                 if (!conflictsWithExistingDefaults(uncheckedCodeDefaults, bottom, loc)) {
                     addUncheckedCodeDefault(bottom, loc);
@@ -236,9 +235,11 @@ public class QualifierDefaults {
      * @param tops AnnotationMirrors that are top
      * @param bottoms AnnotationMirrors that are bottom
      */
-    public void addClimbStandardDefaults(
-            Iterable<? extends AnnotationMirror> tops,
-            Iterable<? extends AnnotationMirror> bottoms) {
+    public void addClimbStandardDefaults() {
+        QualifierHierarchy qualHierarchy = this.atypeFactory.getQualifierHierarchy();
+        Set<? extends AnnotationMirror> tops = qualHierarchy.getTopAnnotations();
+        Set<? extends AnnotationMirror> bottoms = qualHierarchy.getBottomAnnotations();
+
         for (TypeUseLocation loc : standardClimbDefaultsTop) {
             for (AnnotationMirror top : tops) {
                 if (!conflictsWithExistingDefaults(checkedCodeDefaults, top, loc)) {


### PR DESCRIPTION
`QualDefault#addCheckedStandardDefaults()` and `QualDefault#addUnCheckedStandardDefaults()` should not ask clients for tops and bottoms, as `QaulDefault` itself keeps a reference to `ATF`. Thus, it should ask `ATF#qualHier` for tops and bottoms. 