### PR TITLE
fix ATF postAsMemberOf so that viewpointAdaptMember wouldn't get called on executables

### DIFF
--- a/framework/src/main/java/org/checkerframework/framework/type/AnnotatedTypeFactory.java
+++ b/framework/src/main/java/org/checkerframework/framework/type/AnnotatedTypeFactory.java
@@ -1433,7 +1433,7 @@ public class AnnotatedTypeFactory implements AnnotationProvider {
             addAnnotationFromFieldInvariant(type, owner, (VariableElement) element);
         }
         addComputedTypeAnnotations(element, type);
-        if (viewpointAdapter != null) {
+        if (viewpointAdapter != null && type.getKind() != TypeKind.EXECUTABLE) {
             viewpointAdapter.viewpointAdaptMember(owner, element, type);
         }
     }


### PR DESCRIPTION
Notice that `asMemberOf` is invoked by both `constructorFromUse` and `methodFromUse` which subsequently causes `viewpointAdaptMember` to be called on constructors and methods. Here is one possible fix for this issue which checks whether postAsMemberOf is called on executables, but it seems too ad-hoc and more like a work-around.