### PR TITLE
Refactoring dotcfg visualizer

### DIFF
--- a/dataflow/src/main/java/org/checkerframework/dataflow/cfg/AbstractCFGVisualizer.java
+++ b/dataflow/src/main/java/org/checkerframework/dataflow/cfg/AbstractCFGVisualizer.java
@@ -1,0 +1,17 @@
+package org.checkerframework.dataflow.cfg;
+
+import java.util.Map;
+import org.checkerframework.dataflow.analysis.*;
+import org.checkerframework.dataflow.cfg.block.Block;
+
+/**
+ * An abstract class of control flow graph visualizer. It provides the methods to generate a control
+ * flow graph in the language of DOT. To achieve this abstract class, you need to override {@link
+ * #init(Map)}, {@link #visualize(ControlFlowGraph, Block, Analysis)}, {@link
+ * #visualizeStore(Store)} and {@link #shutdown()}.
+ *
+ * <p>Examples: {@link DOTCFGVisualizer} and {@link StringCFGVisualizer}.
+ */
+public abstract class AbstractCFGVisualizer<
+                A extends AbstractValue<A>, S extends Store<S>, T extends TransferFunction<A, S>>
+        implements CFGVisualizer<A, S, T> {}

--- a/dataflow/src/main/java/org/checkerframework/dataflow/cfg/AbstractCFGVisualizer.java
+++ b/dataflow/src/main/java/org/checkerframework/dataflow/cfg/AbstractCFGVisualizer.java
@@ -10,9 +10,8 @@ import org.checkerframework.dataflow.cfg.block.SpecialBlock;
 import org.checkerframework.dataflow.cfg.node.Node;
 
 /**
- * An abstract class of control flow graph visualizer. It provides the methods to generate a control
- * flow graph in the language of DOT. To achieve this abstract class, you need to override {@link
- * #init(Map)}, {@link #visualize(ControlFlowGraph, Block, Analysis)} and {@link #shutdown()}.
+ * An abstract class of control flow graph visualizer. To achieve this abstract class, you need to
+ * implement some of the methods in {@link CFGVisualizer}.
  *
  * <p>Examples: {@link DOTCFGVisualizer} and {@link StringCFGVisualizer}.
  */
@@ -48,9 +47,7 @@ public abstract class AbstractCFGVisualizer<
         IdentityHashMap<Block, List<Integer>> depthFirstOrder = new IdentityHashMap<>();
         int count = 1;
         for (Block b : cfg.getDepthFirstOrderedBlocks()) {
-            if (depthFirstOrder.get(b) == null) {
-                depthFirstOrder.put(b, new ArrayList<>());
-            }
+            depthFirstOrder.computeIfAbsent(b, k -> new ArrayList<>());
             depthFirstOrder.get(b).add(count++);
         }
         return depthFirstOrder;
@@ -185,92 +182,11 @@ public abstract class AbstractCFGVisualizer<
         return s.replace("\"", "\\\"");
     }
 
-    @Override
-    public String visualizeStore(S store) {
-        String sbStoreBackup = this.sbStore.toString();
-        this.sbStore.setLength(0);
-        store.visualize(this);
-        String sbStoreReturnValue = this.sbStore.toString();
-        this.sbStore.setLength(0);
-        this.sbStore.append(sbStoreBackup).append(sbStoreReturnValue);
-        return sbStoreReturnValue;
-    }
-
-    @Override
-    public void visualizeStoreThisVal(A value) {
-        this.sbStore.append("  this > ").append(value).append("\\n");
-    }
-
-    @Override
-    public void visualizeStoreLocalVar(FlowExpressions.LocalVariable localVar, A value) {
-        this.sbStore
-                .append("  ")
-                .append(localVar)
-                .append(" > ")
-                .append(toStringEscapeDoubleQuotes(value))
-                .append("\\n");
-    }
-
-    @Override
-    public void visualizeStoreFieldVals(FlowExpressions.FieldAccess fieldAccess, A value) {
-        this.sbStore
-                .append("  ")
-                .append(fieldAccess)
-                .append(" > ")
-                .append(toStringEscapeDoubleQuotes(value))
-                .append("\\n");
-    }
-
-    @Override
-    public void visualizeStoreArrayVal(FlowExpressions.ArrayAccess arrayValue, A value) {
-        this.sbStore
-                .append("  ")
-                .append(arrayValue)
-                .append(" > ")
-                .append(toStringEscapeDoubleQuotes(value))
-                .append("\\n");
-    }
-
-    @Override
-    public void visualizeStoreMethodVals(FlowExpressions.MethodCall methodCall, A value) {
-        this.sbStore
-                .append("  ")
-                .append(methodCall.toString().replace("\"", "\\\""))
-                .append(" > ")
-                .append(value)
-                .append("\\n");
-    }
-
-    @Override
-    public void visualizeStoreClassVals(FlowExpressions.ClassName className, A value) {
-        this.sbStore
-                .append("  ")
-                .append(className)
-                .append(" > ")
-                .append(toStringEscapeDoubleQuotes(value))
-                .append("\\n");
-    }
-
-    @Override
-    public void visualizeStoreKeyVal(String keyName, Object value) {
-        this.sbStore.append("  ").append(keyName).append(" = ").append(value).append("\\n");
-    }
-
     protected String escapeDoubleQuotes(final String str) {
         return str.replace("\"", "\\\"");
     }
 
     protected String toStringEscapeDoubleQuotes(final Object obj) {
         return escapeDoubleQuotes(String.valueOf(obj));
-    }
-
-    @Override
-    public void visualizeStoreHeader(String classCanonicalName) {
-        this.sbStore.append(classCanonicalName).append(" (\\n");
-    }
-
-    @Override
-    public void visualizeStoreFooter() {
-        this.sbStore.append(")");
     }
 }

--- a/dataflow/src/main/java/org/checkerframework/dataflow/cfg/AbstractCFGVisualizer.java
+++ b/dataflow/src/main/java/org/checkerframework/dataflow/cfg/AbstractCFGVisualizer.java
@@ -1,8 +1,13 @@
 package org.checkerframework.dataflow.cfg;
 
-import java.util.Map;
+import java.util.*;
+import org.checkerframework.checker.nullness.qual.Nullable;
 import org.checkerframework.dataflow.analysis.*;
 import org.checkerframework.dataflow.cfg.block.Block;
+import org.checkerframework.dataflow.cfg.block.ExceptionBlock;
+import org.checkerframework.dataflow.cfg.block.RegularBlock;
+import org.checkerframework.dataflow.cfg.block.SpecialBlock;
+import org.checkerframework.dataflow.cfg.node.Node;
 
 /**
  * An abstract class of control flow graph visualizer. It provides the methods to generate a control
@@ -14,4 +19,259 @@ import org.checkerframework.dataflow.cfg.block.Block;
  */
 public abstract class AbstractCFGVisualizer<
                 A extends AbstractValue<A>, S extends Store<S>, T extends TransferFunction<A, S>>
-        implements CFGVisualizer<A, S, T> {}
+        implements CFGVisualizer<A, S, T> {
+
+    protected boolean verbose;
+
+    protected StringBuilder sbStore;
+    protected StringBuilder sbBlock;
+
+    @Override
+    public void init(Map<String, Object> args) {
+        {
+            Object verb = args.get("verbose");
+            this.verbose =
+                    verb != null
+                            && (verb instanceof String
+                                    ? Boolean.getBoolean((String) verb)
+                                    : (boolean) verb);
+        }
+        this.sbStore = new StringBuilder();
+        this.sbBlock = new StringBuilder();
+    }
+
+    /**
+     * Generate the order of processing blocks.
+     *
+     * @param cfg the current control flow graph
+     */
+    protected IdentityHashMap<Block, List<Integer>> getProcessOrder(ControlFlowGraph cfg) {
+        IdentityHashMap<Block, List<Integer>> depthFirstOrder = new IdentityHashMap<>();
+        int count = 1;
+        for (Block b : cfg.getDepthFirstOrderedBlocks()) {
+            if (depthFirstOrder.get(b) == null) {
+                depthFirstOrder.put(b, new ArrayList<>());
+            }
+            depthFirstOrder.get(b).add(count++);
+        }
+        return depthFirstOrder;
+    }
+
+    protected void loopOverContents(
+            Block bb, List<Node> contents, @Nullable Analysis<A, S, T> analysis) {
+        switchBlockType(bb, contents);
+        boolean notFirst = false;
+        for (Node t : contents) {
+            if (notFirst) {
+                this.sbBlock.append("\\n");
+            }
+            notFirst = true;
+            visualizeBlockNode(t, analysis);
+        }
+    }
+
+    protected void switchBlockType(Block bb, List<Node> contents) {
+        switch (bb.getType()) {
+            case REGULAR_BLOCK:
+                contents.addAll(((RegularBlock) bb).getContents());
+                break;
+            case EXCEPTION_BLOCK:
+                contents.add(((ExceptionBlock) bb).getNode());
+                break;
+            case CONDITIONAL_BLOCK:
+                break;
+            case SPECIAL_BLOCK:
+                break;
+            default:
+                assert false : "All types of basic blocks covered";
+        }
+    }
+
+    @Override
+    public void visualizeSpecialBlock(SpecialBlock sbb) {
+        switch (sbb.getSpecialType()) {
+            case ENTRY:
+                this.sbBlock.append("<entry>");
+                break;
+            case EXIT:
+                this.sbBlock.append("<exit>");
+                break;
+            case EXCEPTIONAL_EXIT:
+                this.sbBlock.append("<exceptional-exit>");
+                break;
+        }
+    }
+
+    @Override
+    public void visualizeBlockTransferInput(Block bb, Analysis<A, S, T> analysis) {
+        assert analysis != null
+                : "analysis should be non-null when visualizing the transfer input of a block.";
+
+        TransferInput<A, S> input = analysis.getInput(bb);
+        assert input != null;
+
+        this.sbStore.setLength(0);
+
+        // split input representation to two lines
+        this.sbStore.append("Before:");
+        if (!input.containsTwoStores()) {
+            S regularStore = input.getRegularStore();
+            this.sbStore.append('[');
+            visualizeStore(regularStore);
+            this.sbStore.append(']');
+        } else {
+            S thenStore = input.getThenStore();
+            this.sbStore.append("[then=");
+            visualizeStore(thenStore);
+            S elseStore = input.getElseStore();
+            this.sbStore.append(", else=");
+            visualizeStore(elseStore);
+            this.sbStore.append("]");
+        }
+        // separator
+        this.sbStore.append("\\n~~~~~~~~~\\n");
+
+        // the transfer input before this block is added before the block content
+        this.sbBlock.insert(0, this.sbStore);
+
+        if (verbose) {
+            Node lastNode;
+            switch (bb.getType()) {
+                case REGULAR_BLOCK:
+                    List<Node> blockContents = ((RegularBlock) bb).getContents();
+                    lastNode = blockContents.get(blockContents.size() - 1);
+                    break;
+                case EXCEPTION_BLOCK:
+                    lastNode = ((ExceptionBlock) bb).getNode();
+                    break;
+                default:
+                    lastNode = null;
+            }
+            if (lastNode != null) {
+                this.sbStore.setLength(0);
+                this.sbStore.append("\\n~~~~~~~~~\\n");
+                this.sbStore.append("After:");
+                visualizeStore(analysis.getResult().getStoreAfter(lastNode));
+                this.sbBlock.append(this.sbStore);
+            }
+        }
+    }
+
+    @Override
+    public void visualizeBlockNode(Node t, @Nullable Analysis<A, S, T> analysis) {
+        this.sbBlock
+                .append(prepareString(t.toString()))
+                .append("   [ ")
+                .append(prepareNodeType(t))
+                .append(" ]");
+        if (analysis != null) {
+            A value = analysis.getValue(t);
+            if (value != null) {
+                this.sbBlock.append("    > ").append(prepareString(value.toString()));
+            }
+        }
+    }
+
+    protected String prepareNodeType(Node t) {
+        String name = t.getClass().getSimpleName();
+        return name.replace("Node", "");
+    }
+
+    /**
+     * Escape double quotes.
+     *
+     * @param s the String to be processed.
+     */
+    protected String prepareString(String s) {
+        return s.replace("\"", "\\\"");
+    }
+
+    @Override
+    public String visualizeStore(S store) {
+        String sbStoreBackup = this.sbStore.toString();
+        this.sbStore.setLength(0);
+        store.visualize(this);
+        String sbStoreReturnValue = this.sbStore.toString();
+        this.sbStore.setLength(0);
+        this.sbStore.append(sbStoreBackup).append(sbStoreReturnValue);
+        return sbStoreReturnValue;
+    }
+
+    @Override
+    public void visualizeStoreThisVal(A value) {
+        this.sbStore.append("  this > ").append(value).append("\\n");
+    }
+
+    @Override
+    public void visualizeStoreLocalVar(FlowExpressions.LocalVariable localVar, A value) {
+        this.sbStore
+                .append("  ")
+                .append(localVar)
+                .append(" > ")
+                .append(toStringEscapeDoubleQuotes(value))
+                .append("\\n");
+    }
+
+    @Override
+    public void visualizeStoreFieldVals(FlowExpressions.FieldAccess fieldAccess, A value) {
+        this.sbStore
+                .append("  ")
+                .append(fieldAccess)
+                .append(" > ")
+                .append(toStringEscapeDoubleQuotes(value))
+                .append("\\n");
+    }
+
+    @Override
+    public void visualizeStoreArrayVal(FlowExpressions.ArrayAccess arrayValue, A value) {
+        this.sbStore
+                .append("  ")
+                .append(arrayValue)
+                .append(" > ")
+                .append(toStringEscapeDoubleQuotes(value))
+                .append("\\n");
+    }
+
+    @Override
+    public void visualizeStoreMethodVals(FlowExpressions.MethodCall methodCall, A value) {
+        this.sbStore
+                .append("  ")
+                .append(methodCall.toString().replace("\"", "\\\""))
+                .append(" > ")
+                .append(value)
+                .append("\\n");
+    }
+
+    @Override
+    public void visualizeStoreClassVals(FlowExpressions.ClassName className, A value) {
+        this.sbStore
+                .append("  ")
+                .append(className)
+                .append(" > ")
+                .append(toStringEscapeDoubleQuotes(value))
+                .append("\\n");
+    }
+
+    @Override
+    public void visualizeStoreKeyVal(String keyName, Object value) {
+        this.sbStore.append("  ").append(keyName).append(" = ").append(value).append("\\n");
+    }
+
+    protected String escapeDoubleQuotes(final String str) {
+        return str.replace("\"", "\\\"");
+    }
+
+    protected String toStringEscapeDoubleQuotes(final Object obj) {
+        return escapeDoubleQuotes(String.valueOf(obj));
+    }
+
+    @Override
+    public void visualizeStoreHeader(String classCanonicalName) {
+        this.sbStore.append(classCanonicalName).append(" (\\n");
+    }
+
+    @Override
+    public void visualizeStoreFooter() {
+        this.sbStore.append(")");
+    }
+}

--- a/dataflow/src/main/java/org/checkerframework/dataflow/cfg/AbstractCFGVisualizer.java
+++ b/dataflow/src/main/java/org/checkerframework/dataflow/cfg/AbstractCFGVisualizer.java
@@ -12,8 +12,7 @@ import org.checkerframework.dataflow.cfg.node.Node;
 /**
  * An abstract class of control flow graph visualizer. It provides the methods to generate a control
  * flow graph in the language of DOT. To achieve this abstract class, you need to override {@link
- * #init(Map)}, {@link #visualize(ControlFlowGraph, Block, Analysis)}, {@link
- * #visualizeStore(Store)} and {@link #shutdown()}.
+ * #init(Map)}, {@link #visualize(ControlFlowGraph, Block, Analysis)} and {@link #shutdown()}.
  *
  * <p>Examples: {@link DOTCFGVisualizer} and {@link StringCFGVisualizer}.
  */

--- a/dataflow/src/main/java/org/checkerframework/dataflow/cfg/CFGVisualizer.java
+++ b/dataflow/src/main/java/org/checkerframework/dataflow/cfg/CFGVisualizer.java
@@ -49,7 +49,7 @@ public interface CFGVisualizer<
      *
      * @param store the store to visualize
      */
-    void visualizeStore(S store);
+    String visualizeStore(S store);
 
     /**
      * Called by a {@code CFAbstractStore} to visualize the class name before calling the {@code

--- a/dataflow/src/main/java/org/checkerframework/dataflow/cfg/CFGVisualizer.java
+++ b/dataflow/src/main/java/org/checkerframework/dataflow/cfg/CFGVisualizer.java
@@ -134,7 +134,7 @@ public interface CFGVisualizer<
      * @param bb the block
      * @param analysis the current analysis
      */
-    void visualizeBlock(Block bb, @Nullable Analysis<A, S, T> analysis);
+    @Nullable String visualizeBlock(Block bb, @Nullable Analysis<A, S, T> analysis);
 
     /**
      * Visualize a SpecialBlock.

--- a/dataflow/src/main/java/org/checkerframework/dataflow/cfg/CFGVisualizer.java
+++ b/dataflow/src/main/java/org/checkerframework/dataflow/cfg/CFGVisualizer.java
@@ -48,8 +48,9 @@ public interface CFGVisualizer<
      * call back to this visualizer instance for sub-components.
      *
      * @param store the store to visualize
+     * @return the String presentation of the value of store
      */
-    String visualizeStore(S store);
+    @Nullable String visualizeStore(S store);
 
     /**
      * Called by a {@code CFAbstractStore} to visualize the class name before calling the {@code
@@ -57,7 +58,7 @@ public interface CFGVisualizer<
      *
      * @param classCanonicalName the canonical name of the class
      */
-    void visualizeStoreHeader(String classCanonicalName);
+    String visualizeStoreHeader(String classCanonicalName);
 
     /**
      * Called by {@code CFAbstractStore#internalVisualize()} to visualize a local variable.
@@ -65,7 +66,7 @@ public interface CFGVisualizer<
      * @param localVar the local variable
      * @param value the value of the local variable
      */
-    void visualizeStoreLocalVar(FlowExpressions.LocalVariable localVar, A value);
+    String visualizeStoreLocalVar(FlowExpressions.LocalVariable localVar, A value);
 
     /**
      * Called by {@code CFAbstractStore#internalVisualize()} to visualize the value of the current
@@ -73,7 +74,7 @@ public interface CFGVisualizer<
      *
      * @param value the value of the current object this
      */
-    void visualizeStoreThisVal(A value);
+    String visualizeStoreThisVal(A value);
 
     /**
      * Called by {@code CFAbstractStore#internalVisualize()} to visualize the value of fields
@@ -82,7 +83,7 @@ public interface CFGVisualizer<
      * @param fieldAccess the field
      * @param value the value of the field
      */
-    void visualizeStoreFieldVals(FlowExpressions.FieldAccess fieldAccess, A value);
+    String visualizeStoreFieldVals(FlowExpressions.FieldAccess fieldAccess, A value);
 
     /**
      * Called by {@code CFAbstractStore#internalVisualize()} to visualize the value of arrays
@@ -91,7 +92,7 @@ public interface CFGVisualizer<
      * @param arrayValue the array
      * @param value the value of the array
      */
-    void visualizeStoreArrayVal(FlowExpressions.ArrayAccess arrayValue, A value);
+    String visualizeStoreArrayVal(FlowExpressions.ArrayAccess arrayValue, A value);
 
     /**
      * Called by {@code CFAbstractStore#internalVisualize()} to visualize the value of pure method
@@ -100,7 +101,7 @@ public interface CFGVisualizer<
      * @param methodCall the pure method call
      * @param value the value of the pure method call
      */
-    void visualizeStoreMethodVals(FlowExpressions.MethodCall methodCall, A value);
+    String visualizeStoreMethodVals(FlowExpressions.MethodCall methodCall, A value);
 
     /**
      * Called by {@code CFAbstractStore#internalVisualize()} to visualize the value of class names
@@ -109,7 +110,7 @@ public interface CFGVisualizer<
      * @param className the class name
      * @param value the value of the class name
      */
-    void visualizeStoreClassVals(FlowExpressions.ClassName className, A value);
+    String visualizeStoreClassVals(FlowExpressions.ClassName className, A value);
 
     /**
      * Called by {@code CFAbstractStore#internalVisualize()} to visualize the specific information
@@ -120,13 +121,13 @@ public interface CFGVisualizer<
      * @param keyName the name of the specific information to be visualized
      * @param value the value of the specific information to be visualized
      */
-    void visualizeStoreKeyVal(String keyName, Object value);
+    String visualizeStoreKeyVal(String keyName, Object value);
 
     /**
      * Called by {@code CFAbstractStore} to visualize any information after the invocation of {@code
      * CFAbstractStore#internalVisualize()}.
      */
-    void visualizeStoreFooter();
+    String visualizeStoreFooter();
 
     /**
      * Visualize a block based on the analysis.

--- a/dataflow/src/main/java/org/checkerframework/dataflow/cfg/DOTCFGVisualizer.java
+++ b/dataflow/src/main/java/org/checkerframework/dataflow/cfg/DOTCFGVisualizer.java
@@ -16,10 +16,7 @@ import java.util.Queue;
 import java.util.Set;
 import javax.lang.model.type.TypeMirror;
 import org.checkerframework.checker.nullness.qual.Nullable;
-import org.checkerframework.dataflow.analysis.AbstractValue;
-import org.checkerframework.dataflow.analysis.Analysis;
-import org.checkerframework.dataflow.analysis.Store;
-import org.checkerframework.dataflow.analysis.TransferFunction;
+import org.checkerframework.dataflow.analysis.*;
 import org.checkerframework.dataflow.cfg.UnderlyingAST.CFGMethod;
 import org.checkerframework.dataflow.cfg.UnderlyingAST.CFGStatement;
 import org.checkerframework.dataflow.cfg.block.Block;
@@ -301,6 +298,97 @@ public class DOTCFGVisualizer<
                 .append(" [label=\"")
                 .append(labelContent)
                 .append("\"];\n");
+    }
+
+    /**
+     * {@inheritDoc}
+     *
+     * <p>Do not call this method by hand. Use {@link StringCFGVisualizer} to see the String version
+     * of the value of store.
+     */
+    @Override
+    public @Nullable String visualizeStore(S store) {
+        store.visualize(this);
+        return null;
+    }
+
+    @Override
+    public String visualizeStoreThisVal(A value) {
+        this.sbStore.append("  this > ").append(value).append("\\n");
+        return null;
+    }
+
+    @Override
+    public String visualizeStoreLocalVar(FlowExpressions.LocalVariable localVar, A value) {
+        this.sbStore
+                .append("  ")
+                .append(localVar)
+                .append(" > ")
+                .append(toStringEscapeDoubleQuotes(value))
+                .append("\\n");
+        return null;
+    }
+
+    @Override
+    public String visualizeStoreFieldVals(FlowExpressions.FieldAccess fieldAccess, A value) {
+        this.sbStore
+                .append("  ")
+                .append(fieldAccess)
+                .append(" > ")
+                .append(toStringEscapeDoubleQuotes(value))
+                .append("\\n");
+        return null;
+    }
+
+    @Override
+    public String visualizeStoreArrayVal(FlowExpressions.ArrayAccess arrayValue, A value) {
+        this.sbStore
+                .append("  ")
+                .append(arrayValue)
+                .append(" > ")
+                .append(toStringEscapeDoubleQuotes(value))
+                .append("\\n");
+        return null;
+    }
+
+    @Override
+    public String visualizeStoreMethodVals(FlowExpressions.MethodCall methodCall, A value) {
+        this.sbStore
+                .append("  ")
+                .append(methodCall.toString().replace("\"", "\\\""))
+                .append(" > ")
+                .append(value)
+                .append("\\n");
+        return null;
+    }
+
+    @Override
+    public String visualizeStoreClassVals(FlowExpressions.ClassName className, A value) {
+        this.sbStore
+                .append("  ")
+                .append(className)
+                .append(" > ")
+                .append(toStringEscapeDoubleQuotes(value))
+                .append("\\n");
+        return null;
+    }
+
+    @Override
+    public String visualizeStoreKeyVal(String keyName, Object value) {
+        this.sbStore.append("  ").append(keyName).append(" = ").append(value).append("\\n");
+        return null;
+    }
+
+    @Override
+    public String visualizeStoreHeader(String classCanonicalName) {
+        this.sbStore.append(classCanonicalName).append(" (\\n");
+        return null;
+    }
+
+    @Override
+    public String visualizeStoreFooter() {
+        this.sbStore.append(")");
+        return null;
     }
 
     /**

--- a/dataflow/src/main/java/org/checkerframework/dataflow/cfg/DOTCFGVisualizer.java
+++ b/dataflow/src/main/java/org/checkerframework/dataflow/cfg/DOTCFGVisualizer.java
@@ -18,17 +18,14 @@ import javax.lang.model.type.TypeMirror;
 import org.checkerframework.checker.nullness.qual.Nullable;
 import org.checkerframework.dataflow.analysis.AbstractValue;
 import org.checkerframework.dataflow.analysis.Analysis;
-import org.checkerframework.dataflow.analysis.FlowExpressions;
 import org.checkerframework.dataflow.analysis.Store;
 import org.checkerframework.dataflow.analysis.TransferFunction;
-import org.checkerframework.dataflow.analysis.TransferInput;
 import org.checkerframework.dataflow.cfg.UnderlyingAST.CFGMethod;
 import org.checkerframework.dataflow.cfg.UnderlyingAST.CFGStatement;
 import org.checkerframework.dataflow.cfg.block.Block;
 import org.checkerframework.dataflow.cfg.block.Block.BlockType;
 import org.checkerframework.dataflow.cfg.block.ConditionalBlock;
 import org.checkerframework.dataflow.cfg.block.ExceptionBlock;
-import org.checkerframework.dataflow.cfg.block.RegularBlock;
 import org.checkerframework.dataflow.cfg.block.SingleSuccessorBlock;
 import org.checkerframework.dataflow.cfg.block.SpecialBlock;
 import org.checkerframework.dataflow.cfg.node.Node;
@@ -40,37 +37,21 @@ public class DOTCFGVisualizer<
                 A extends AbstractValue<A>, S extends Store<S>, T extends TransferFunction<A, S>>
         extends AbstractCFGVisualizer<A, S, T> {
 
-    protected String outdir;
-    protected boolean verbose;
-    protected String checkerName;
+    private String outdir;
+    private String checkerName;
 
-    protected StringBuilder sbDigraph;
-    protected StringBuilder sbStore;
-    protected StringBuilder sbBlock;
+    private StringBuilder sbDigraph;
 
     /** Mapping from class/method representation to generated dot file. */
     protected Map<String, String> generated;
 
     @Override
     public void init(Map<String, Object> args) {
+        super.init(args);
         this.outdir = (String) args.get("outdir");
-        {
-            Object verb = args.get("verbose");
-            this.verbose =
-                    verb != null
-                            && (verb instanceof String
-                                    ? Boolean.getBoolean((String) verb)
-                                    : (boolean) verb);
-        }
         this.checkerName = (String) args.get("checkerName");
-
         this.generated = new HashMap<>();
-
         this.sbDigraph = new StringBuilder();
-
-        this.sbStore = new StringBuilder();
-
-        this.sbBlock = new StringBuilder();
     }
 
     @Override
@@ -209,7 +190,12 @@ public class DOTCFGVisualizer<
         this.sbDigraph.append("\n");
     }
 
-    /** @return the file name used for DOT output. */
+    /**
+     * Create the name of dot file.
+     *
+     * @param ast an abstract syntax tree
+     * @return the file name used for DOT output
+     */
     private String dotOutputFileName(UnderlyingAST ast) {
         StringBuilder srcloc = new StringBuilder();
 
@@ -260,57 +246,18 @@ public class DOTCFGVisualizer<
     }
 
     /**
-     * Generate the order of processing blocks.
-     *
-     * @param cfg the current control flow graph
-     */
-    protected IdentityHashMap<Block, List<Integer>> getProcessOrder(ControlFlowGraph cfg) {
-        IdentityHashMap<Block, List<Integer>> depthFirstOrder = new IdentityHashMap<>();
-        int count = 1;
-        for (Block b : cfg.getDepthFirstOrderedBlocks()) {
-            if (depthFirstOrder.get(b) == null) {
-                depthFirstOrder.put(b, new ArrayList<>());
-            }
-            depthFirstOrder.get(b).add(count++);
-        }
-        return depthFirstOrder;
-    }
-
-    /**
      * Produce a representation of the contests of a basic block.
      *
      * @param bb basic block to visualize
      * @param analysis the current analysis
      */
     @Override
-    public void visualizeBlock(Block bb, @Nullable Analysis<A, S, T> analysis) {
+    public @Nullable String visualizeBlock(Block bb, @Nullable Analysis<A, S, T> analysis) {
 
         this.sbBlock.setLength(0);
 
-        // loop over contents
         List<Node> contents = new ArrayList<>();
-        switch (bb.getType()) {
-            case REGULAR_BLOCK:
-                contents.addAll(((RegularBlock) bb).getContents());
-                break;
-            case EXCEPTION_BLOCK:
-                contents.add(((ExceptionBlock) bb).getNode());
-                break;
-            case CONDITIONAL_BLOCK:
-                break;
-            case SPECIAL_BLOCK:
-                break;
-            default:
-                assert false : "All types of basic blocks covered";
-        }
-        boolean notFirst = false;
-        for (Node t : contents) {
-            if (notFirst) {
-                this.sbBlock.append("\\n");
-            }
-            notFirst = true;
-            visualizeBlockNode(t, analysis);
-        }
+        loopOverContents(bb, contents, analysis);
 
         // handle case where no contents are present
         boolean centered = false;
@@ -320,10 +267,10 @@ public class DOTCFGVisualizer<
                 visualizeSpecialBlock((SpecialBlock) bb);
             } else if (bb.getType() == BlockType.CONDITIONAL_BLOCK) {
                 this.sbDigraph.append(" \",];\n");
-                return;
+                return null;
             } else {
                 this.sbDigraph.append("?? empty ?? \",];\n");
-                return;
+                return null;
             }
         }
 
@@ -335,105 +282,7 @@ public class DOTCFGVisualizer<
         this.sbDigraph
                 .append((this.sbBlock.toString() + (centered ? "" : "\\n")).replace("\\n", "\\l"))
                 .append(" \",];\n");
-    }
-
-    @Override
-    public void visualizeSpecialBlock(SpecialBlock sbb) {
-        switch (sbb.getSpecialType()) {
-            case ENTRY:
-                this.sbBlock.append("<entry>");
-                break;
-            case EXIT:
-                this.sbBlock.append("<exit>");
-                break;
-            case EXCEPTIONAL_EXIT:
-                this.sbBlock.append("<exceptional-exit>");
-                break;
-        }
-    }
-
-    @Override
-    public void visualizeBlockTransferInput(Block bb, Analysis<A, S, T> analysis) {
-        assert analysis != null
-                : "analysis should be non-null when visualizing the transfer input of a block.";
-
-        TransferInput<A, S> input = analysis.getInput(bb);
-        assert input != null;
-
-        this.sbStore.setLength(0);
-
-        // split input representation to two lines
-        this.sbStore.append("Before:");
-        if (!input.containsTwoStores()) {
-            S regularStore = input.getRegularStore();
-            this.sbStore.append('[');
-            visualizeStore(regularStore);
-            this.sbStore.append(']');
-        } else {
-            S thenStore = input.getThenStore();
-            this.sbStore.append("[then=");
-            visualizeStore(thenStore);
-            S elseStore = input.getElseStore();
-            this.sbStore.append(", else=");
-            visualizeStore(elseStore);
-            this.sbStore.append("]");
-        }
-        // separator
-        this.sbStore.append("\\n~~~~~~~~~\\n");
-
-        // the transfer input before this block is added before the block content
-        this.sbBlock.insert(0, this.sbStore);
-
-        if (verbose) {
-            Node lastNode;
-            switch (bb.getType()) {
-                case REGULAR_BLOCK:
-                    List<Node> blockContents = ((RegularBlock) bb).getContents();
-                    lastNode = blockContents.get(blockContents.size() - 1);
-                    break;
-                case EXCEPTION_BLOCK:
-                    lastNode = ((ExceptionBlock) bb).getNode();
-                    break;
-                default:
-                    lastNode = null;
-            }
-            if (lastNode != null) {
-                this.sbStore.setLength(0);
-                this.sbStore.append("\\n~~~~~~~~~\\n");
-                this.sbStore.append("After:");
-                visualizeStore(analysis.getResult().getStoreAfter(lastNode));
-                this.sbBlock.append(this.sbStore);
-            }
-        }
-    }
-
-    @Override
-    public void visualizeBlockNode(Node t, @Nullable Analysis<A, S, T> analysis) {
-        this.sbBlock
-                .append(prepareString(t.toString()))
-                .append("   [ ")
-                .append(prepareNodeType(t))
-                .append(" ]");
-        if (analysis != null) {
-            A value = analysis.getValue(t);
-            if (value != null) {
-                this.sbBlock.append("    > ").append(prepareString(value.toString()));
-            }
-        }
-    }
-
-    protected String prepareNodeType(Node t) {
-        String name = t.getClass().getSimpleName();
-        return name.replace("Node", "");
-    }
-
-    /**
-     * Escape double quotes.
-     *
-     * @param s the String to be processed.
-     */
-    protected String prepareString(String s) {
-        return s.replace("\"", "\\\"");
+        return this.sbBlock.toString();
     }
 
     /**
@@ -452,95 +301,6 @@ public class DOTCFGVisualizer<
                 .append(" [label=\"")
                 .append(labelContent)
                 .append("\"];\n");
-    }
-
-    @Override
-    public String visualizeStore(S store) {
-        String sbStoreBackup = this.sbStore.toString();
-        this.sbStore.setLength(0);
-        store.visualize(this);
-        String sbStoreReturnValue = this.sbStore.toString();
-        this.sbStore.setLength(0);
-        this.sbStore.append(sbStoreBackup).append(sbStoreReturnValue);
-        return sbStoreReturnValue;
-    }
-
-    @Override
-    public void visualizeStoreThisVal(A value) {
-        this.sbStore.append("  this > ").append(value).append("\\n");
-    }
-
-    @Override
-    public void visualizeStoreLocalVar(FlowExpressions.LocalVariable localVar, A value) {
-        this.sbStore
-                .append("  ")
-                .append(localVar)
-                .append(" > ")
-                .append(toStringEscapeDoubleQuotes(value))
-                .append("\\n");
-    }
-
-    @Override
-    public void visualizeStoreFieldVals(FlowExpressions.FieldAccess fieldAccess, A value) {
-        this.sbStore
-                .append("  ")
-                .append(fieldAccess)
-                .append(" > ")
-                .append(toStringEscapeDoubleQuotes(value))
-                .append("\\n");
-    }
-
-    @Override
-    public void visualizeStoreArrayVal(FlowExpressions.ArrayAccess arrayValue, A value) {
-        this.sbStore
-                .append("  ")
-                .append(arrayValue)
-                .append(" > ")
-                .append(toStringEscapeDoubleQuotes(value))
-                .append("\\n");
-    }
-
-    @Override
-    public void visualizeStoreMethodVals(FlowExpressions.MethodCall methodCall, A value) {
-        this.sbStore
-                .append("  ")
-                .append(methodCall.toString().replace("\"", "\\\""))
-                .append(" > ")
-                .append(value)
-                .append("\\n");
-    }
-
-    @Override
-    public void visualizeStoreClassVals(FlowExpressions.ClassName className, A value) {
-        this.sbStore
-                .append("  ")
-                .append(className)
-                .append(" > ")
-                .append(toStringEscapeDoubleQuotes(value))
-                .append("\\n");
-    }
-
-    @Override
-    public void visualizeStoreKeyVal(String keyName, Object value) {
-        this.sbStore.append("  ").append(keyName).append(" = ").append(value).append("\\n");
-    }
-
-    protected String escapeDoubleQuotes(final String str) {
-        return str.replace("\"", "\\\"");
-    }
-
-    protected String toStringEscapeDoubleQuotes(final Object obj) {
-        return escapeDoubleQuotes(String.valueOf(obj));
-    }
-
-    @Override
-    public void visualizeStoreHeader(String classCanonicalName) {
-        this.sbStore.append(classCanonicalName).append(" (\\n");
-    }
-
-    @Override
-    public void visualizeStoreFooter() {
-        this.sbStore.append(")");
     }
 
     /**

--- a/dataflow/src/main/java/org/checkerframework/dataflow/cfg/StringCFGVisualizer.java
+++ b/dataflow/src/main/java/org/checkerframework/dataflow/cfg/StringCFGVisualizer.java
@@ -1,0 +1,3 @@
+package org.checkerframework.dataflow.cfg;
+
+public class StringCFGVisualizer {}

--- a/dataflow/src/main/java/org/checkerframework/dataflow/cfg/StringCFGVisualizer.java
+++ b/dataflow/src/main/java/org/checkerframework/dataflow/cfg/StringCFGVisualizer.java
@@ -2,10 +2,7 @@ package org.checkerframework.dataflow.cfg;
 
 import java.util.*;
 import org.checkerframework.checker.nullness.qual.Nullable;
-import org.checkerframework.dataflow.analysis.AbstractValue;
-import org.checkerframework.dataflow.analysis.Analysis;
-import org.checkerframework.dataflow.analysis.Store;
-import org.checkerframework.dataflow.analysis.TransferFunction;
+import org.checkerframework.dataflow.analysis.*;
 import org.checkerframework.dataflow.cfg.block.Block;
 import org.checkerframework.dataflow.cfg.node.Node;
 
@@ -44,6 +41,94 @@ public class StringCFGVisualizer<
             visualizeBlockTransferInput(bb, analysis);
         }
         return this.sbBlock.toString();
+    }
+
+    @Override
+    public @Nullable String visualizeStore(S store) {
+        if (this.sbStore.length() > 0) {
+            this.sbStore.setLength(0);
+        }
+        store.visualize(this);
+        return this.sbStore.toString();
+    }
+
+    @Override
+    public String visualizeStoreThisVal(A value) {
+        this.sbStore.append("  this > ").append(value).append("\\n");
+        return "this > " + value.toString();
+    }
+
+    @Override
+    public String visualizeStoreLocalVar(FlowExpressions.LocalVariable localVar, A value) {
+        this.sbStore
+                .append("  ")
+                .append(localVar)
+                .append(" > ")
+                .append(toStringEscapeDoubleQuotes(value))
+                .append("\\n");
+        return localVar.toString() + " > " + value.toString();
+    }
+
+    @Override
+    public String visualizeStoreFieldVals(FlowExpressions.FieldAccess fieldAccess, A value) {
+        this.sbStore
+                .append("  ")
+                .append(fieldAccess)
+                .append(" > ")
+                .append(toStringEscapeDoubleQuotes(value))
+                .append("\\n");
+        return fieldAccess.toString() + " > " + value.toString();
+    }
+
+    @Override
+    public String visualizeStoreArrayVal(FlowExpressions.ArrayAccess arrayValue, A value) {
+        this.sbStore
+                .append("  ")
+                .append(arrayValue)
+                .append(" > ")
+                .append(toStringEscapeDoubleQuotes(value))
+                .append("\\n");
+        return arrayValue.toString() + " > " + value.toString();
+    }
+
+    @Override
+    public String visualizeStoreMethodVals(FlowExpressions.MethodCall methodCall, A value) {
+        this.sbStore
+                .append("  ")
+                .append(methodCall.toString().replace("\"", "\\\""))
+                .append(" > ")
+                .append(value)
+                .append("\\n");
+        return methodCall.toString() + " > " + value.toString();
+    }
+
+    @Override
+    public String visualizeStoreClassVals(FlowExpressions.ClassName className, A value) {
+        this.sbStore
+                .append("  ")
+                .append(className)
+                .append(" > ")
+                .append(toStringEscapeDoubleQuotes(value))
+                .append("\\n");
+        return className.toString() + " > " + value.toString();
+    }
+
+    @Override
+    public String visualizeStoreKeyVal(String keyName, Object value) {
+        this.sbStore.append("  ").append(keyName).append(" = ").append(value).append("\\n");
+        return keyName + " = " + value.toString();
+    }
+
+    @Override
+    public String visualizeStoreHeader(String classCanonicalName) {
+        this.sbStore.append(classCanonicalName).append(" (\\n");
+        return classCanonicalName;
+    }
+
+    @Override
+    public String visualizeStoreFooter() {
+        this.sbStore.append(")");
+        return ")";
     }
 
     /** StringCFGVisualizer does not write into file, so leave it blank. */

--- a/dataflow/src/main/java/org/checkerframework/dataflow/cfg/StringCFGVisualizer.java
+++ b/dataflow/src/main/java/org/checkerframework/dataflow/cfg/StringCFGVisualizer.java
@@ -1,3 +1,51 @@
 package org.checkerframework.dataflow.cfg;
 
-public class StringCFGVisualizer {}
+import java.util.*;
+import org.checkerframework.checker.nullness.qual.Nullable;
+import org.checkerframework.dataflow.analysis.AbstractValue;
+import org.checkerframework.dataflow.analysis.Analysis;
+import org.checkerframework.dataflow.analysis.Store;
+import org.checkerframework.dataflow.analysis.TransferFunction;
+import org.checkerframework.dataflow.cfg.block.Block;
+import org.checkerframework.dataflow.cfg.node.Node;
+
+public class StringCFGVisualizer<
+                A extends AbstractValue<A>, S extends Store<S>, T extends TransferFunction<A, S>>
+        extends AbstractCFGVisualizer<A, S, T> {
+
+    @Override
+    public void init(Map<String, Object> args) {
+        super.init(args);
+    }
+
+    @Override
+    public @Nullable Map<String, Object> visualize(
+            ControlFlowGraph cfg, Block entry, @Nullable Analysis<A, S, T> analysis) {
+        Set<Block> blocks = cfg.getAllBlocks();
+        StringBuilder sbAllBlocks = new StringBuilder();
+        for (Block eachBlock : blocks) {
+            sbAllBlocks.append(eachBlock.toString()).append("\n");
+        }
+        Map<String, Object> res = new HashMap<>();
+        res.put("allBlocks", sbAllBlocks.toString());
+        return res;
+    }
+
+    @Override
+    public @Nullable String visualizeBlock(Block bb, @Nullable Analysis<A, S, T> analysis) {
+
+        this.sbBlock.setLength(0);
+
+        List<Node> contents = new ArrayList<>();
+        loopOverContents(bb, contents, analysis);
+
+        if (analysis != null) {
+            visualizeBlockTransferInput(bb, analysis);
+        }
+        return this.sbBlock.toString();
+    }
+
+    /** StringCFGVisualizer does not write into file, so leave it blank. */
+    @Override
+    public void shutdown() {}
+}

--- a/dataflow/src/main/java/org/checkerframework/dataflow/cfg/StringCFGVisualizer.java
+++ b/dataflow/src/main/java/org/checkerframework/dataflow/cfg/StringCFGVisualizer.java
@@ -9,6 +9,7 @@ import org.checkerframework.dataflow.analysis.TransferFunction;
 import org.checkerframework.dataflow.cfg.block.Block;
 import org.checkerframework.dataflow.cfg.node.Node;
 
+/** Generate a String version of a control flow graph. */
 public class StringCFGVisualizer<
                 A extends AbstractValue<A>, S extends Store<S>, T extends TransferFunction<A, S>>
         extends AbstractCFGVisualizer<A, S, T> {


### PR DESCRIPTION
Hello, in this PR, I refactor DOTCFGVisualizer, create AbstractCFGVisualizer and StringCFGVisualizer. Also, I modify the interface CFGVisualizer to support returning String in some methods. Both DOTCFGVisualizer and StringCFGVisualizer implement AbstractCFGVisualizer. 

For DOTCFGVisualizer, I keep all the functions unchanged. 

And for StringCFGVisualizer, when we call `visualize()`, it will return a map which value is a string includes all the name of blocks. Also, we can call `visualizeBlock` to get the string version of `this.sbBlock`, `visualizeStore` to return the string version of `this.sbStore`. In addition, `visualizeStoreThisVal`, `visualizeStoreLocalVar`, `visualizeStoreFieldVals`, `visualizeStoreArrayVal`, `visualizeStoreMethodVals`, `visualizeStoreClassVals`, `visualizeStoreKeyVal`, `visualizeStoreHeader` and `visualizeStoreFooter` will return simple strings.

If there is something needs to be changed, please let me know.