### PR TITLE
Use TypeAnnotationUtils.unannotatedType() to beautify the output of error [type.invalid.annotations.on.use].

### DIFF
--- a/framework/src/main/java/org/checkerframework/common/basetype/BaseTypeValidator.java
+++ b/framework/src/main/java/org/checkerframework/common/basetype/BaseTypeValidator.java
@@ -160,8 +160,8 @@ public class BaseTypeValidator extends AnnotatedTypeScanner<Void, Tree> implemen
             final Tree p) {
         // TODO: if underlying is a compound type such as List<@Palindrome String>, then it would be
         // nice to print it as "List" instead of as "List<@Palindrome String>".
-        TypeMirror underlying = type.getUnderlyingType();
-        checker.report(Result.failure(errorType, type.getAnnotations(), underlying.toString()), p);
+        TypeMirror unannotated = TypeAnnotationUtils.unannotatedType(type.getUnderlyingType());
+        checker.report(Result.failure(errorType, type.getAnnotations(), unannotated.toString()), p);
         isValid = false;
     }
 


### PR DESCRIPTION
Hello, this PR improves the output of the error `type.invalid.annotations.on.use`.

Former output:
```
checker/tests/nullness/Issue2247.java:16: error: [type.invalid.annotations.on.use] invalid type:
        annotations [@Initialized, @Nullable] conflict with declaration of type
        (@org.checkerframework.checker.nullness.qual.Nullable :: Issue2247.DeclaredClass)
```

Now it looks like:
```
checker/tests/nullness/Issue2247.java:16: error: [type.invalid.annotations.on.use] invalid type:
        annotations [@Initialized, @Nullable] conflict with declaration of type Issue2247.DeclaredClass
```

Please give me some comments. If it looks good, I will open another PR at typetools.

For test case, please also give me some advises. Since there are many existing test files which include this kind of errors, all of them can reproduce the output, e.g., `checker-framework/checker/tests/nullness/Issue2247.java`. Should I write another test case to reproduce the output? Or I can use an existing one and mention it in the description of PR.