### PR TITLE
Fix time-out error and out-of-memory error

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -62,7 +62,7 @@ script:
   else
     DOCKERIMAGE=mdernst/cf-$OS-$JDKVER
   fi &&
-  echo "Using" $DOCKERIMAGE
+  echo "Using docker image: " $DOCKERIMAGE
   docker run -v $HOME/.gradle:/root/.gradle -v $HOME/.m2:/root/.m2 $DOCKERIMAGE /bin/bash -c "true &&
      if [ $TRAVIS_EVENT_TYPE = pull_request ] ; then
        git clone --quiet $REMOTE_ORIGIN_URL $THIS_REPO || git clone --quiet $REMOTE_ORIGIN_URL $THIS_REPO

--- a/.travis.yml
+++ b/.travis.yml
@@ -57,7 +57,7 @@ script:
 - echo "TRAVIS_PULL_REQUEST_SLUG=${TRAVIS_PULL_REQUEST_SLUG}"
 - echo "TRAVIS_REPO_SLUG=${TRAVIS_REPO_SLUG}"
 - >-
-  if [ $GROUP = checker-framework-inference || $GROUP = downstream ] ; then
+  if [ $GROUP = checker-framework-inference ] || [ $GROUP = downstream ] ; then
     DOCKERIMAGE=xingweitian/$OS-for-cfi-$JDKVER
   else
     DOCKERIMAGE=mdernst/cf-$OS-$JDKVER

--- a/.travis.yml
+++ b/.travis.yml
@@ -57,7 +57,12 @@ script:
 - echo "TRAVIS_PULL_REQUEST_SLUG=${TRAVIS_PULL_REQUEST_SLUG}"
 - echo "TRAVIS_REPO_SLUG=${TRAVIS_REPO_SLUG}"
 - >-
-  docker run -v $HOME/.gradle:/root/.gradle -v $HOME/.m2:/root/.m2 mdernst/cf-$OS-$JDKVER /bin/bash -c "true &&
+  if [ $GROUP = checker-framework-inference || $GROUP = downstream ] ; then
+      DOCKERIMAGE=xingweitian/$OS-for-cfi-$JDKVER
+  else
+      DOCKERIMAGE=mdernst/cf-$OS-$JDKVER
+  fi &&
+  docker run -v $HOME/.gradle:/root/.gradle -v $HOME/.m2:/root/.m2 $DOCKERIMAGE /bin/bash -c "true &&
      if [ $TRAVIS_EVENT_TYPE = pull_request ] ; then
        git clone --quiet $REMOTE_ORIGIN_URL $THIS_REPO || git clone --quiet $REMOTE_ORIGIN_URL $THIS_REPO
        cd $THIS_REPO

--- a/.travis.yml
+++ b/.travis.yml
@@ -62,7 +62,7 @@ script:
   else
     DOCKERIMAGE=mdernst/cf-$OS-$JDKVER
   fi &&
-  echo "Using docker image: " $DOCKERIMAGE
+  echo "Using docker image: " $DOCKERIMAGE &&
   docker run -v $HOME/.gradle:/root/.gradle -v $HOME/.m2:/root/.m2 $DOCKERIMAGE /bin/bash -c "true &&
      if [ $TRAVIS_EVENT_TYPE = pull_request ] ; then
        git clone --quiet $REMOTE_ORIGIN_URL $THIS_REPO || git clone --quiet $REMOTE_ORIGIN_URL $THIS_REPO

--- a/.travis.yml
+++ b/.travis.yml
@@ -58,9 +58,9 @@ script:
 - echo "TRAVIS_REPO_SLUG=${TRAVIS_REPO_SLUG}"
 - >-
   if [ $GROUP = checker-framework-inference || $GROUP = downstream ] ; then
-      DOCKERIMAGE=xingweitian/$OS-for-cfi-$JDKVER
+    DOCKERIMAGE=xingweitian/$OS-for-cfi-$JDKVER
   else
-      DOCKERIMAGE=mdernst/cf-$OS-$JDKVER
+    DOCKERIMAGE=mdernst/cf-$OS-$JDKVER
   fi &&
   docker run -v $HOME/.gradle:/root/.gradle -v $HOME/.m2:/root/.m2 $DOCKERIMAGE /bin/bash -c "true &&
      if [ $TRAVIS_EVENT_TYPE = pull_request ] ; then

--- a/.travis.yml
+++ b/.travis.yml
@@ -33,7 +33,6 @@ env:
 # The "docker run" command will pull if needed.
 # Running this first gives two tries in case of network lossage.
 before_script:
-- timeout 5m docker pull xingweitian/$OS-for-cfi-$JDKVER || true
 - timeout 5m docker pull mdernst/cf-$OS-$JDKVER || true
 
 # Using travis_wait here seems to cause the job to terminate after 1 minute
@@ -58,12 +57,7 @@ script:
 - echo "TRAVIS_PULL_REQUEST_SLUG=${TRAVIS_PULL_REQUEST_SLUG}"
 - echo "TRAVIS_REPO_SLUG=${TRAVIS_REPO_SLUG}"
 - >-
-  if [ $JDKVER = jdk8-plus ] ; then
-    DOCKERIMAGE=mdernst/cf-$OS-$JDKVER
-  else
-    DOCKERIMAGE=xingweitian/$OS-for-cfi-$JDKVER
-  fi &&
-  docker run -v $HOME/.gradle:/root/.gradle -v $HOME/.m2:/root/.m2 $DOCKERIMAGE /bin/bash -c "true &&
+  docker run -v $HOME/.gradle:/root/.gradle -v $HOME/.m2:/root/.m2 mdernst/cf-$OS-$JDKVER /bin/bash -c "true &&
      if [ $TRAVIS_EVENT_TYPE = pull_request ] ; then
        git clone --quiet $REMOTE_ORIGIN_URL $THIS_REPO || git clone --quiet $REMOTE_ORIGIN_URL $THIS_REPO
        cd $THIS_REPO

--- a/.travis.yml
+++ b/.travis.yml
@@ -33,6 +33,7 @@ env:
 # The "docker run" command will pull if needed.
 # Running this first gives two tries in case of network lossage.
 before_script:
+- timeout 5m docker pull xingweitian/$OS-for-cfi-$JDKVER || true
 - timeout 5m docker pull mdernst/cf-$OS-$JDKVER || true
 
 # Using travis_wait here seems to cause the job to terminate after 1 minute

--- a/.travis.yml
+++ b/.travis.yml
@@ -62,6 +62,7 @@ script:
   else
     DOCKERIMAGE=mdernst/cf-$OS-$JDKVER
   fi &&
+  echo "Using" $DOCKERIMAGE
   docker run -v $HOME/.gradle:/root/.gradle -v $HOME/.m2:/root/.m2 $DOCKERIMAGE /bin/bash -c "true &&
      if [ $TRAVIS_EVENT_TYPE = pull_request ] ; then
        git clone --quiet $REMOTE_ORIGIN_URL $THIS_REPO || git clone --quiet $REMOTE_ORIGIN_URL $THIS_REPO


### PR DESCRIPTION
It is so awkward that poor performance is caused by my docker image... I still don't know why only Java 11 works badly with my docker image, but this PR should make cf green again.

The solution, for now, is: only use my docker image in test groups `checker-framework-inference` and `downstream`. The logic is the same as xingweitian/checker-framework#3. Also, do not pull my docker image every time in `before_script`, this will also save time.

Resolve #103.