### PR TITLE
Update JAVA_HOME export cmd in docs

### DIFF
--- a/docs/manual/troubleshooting.tex
+++ b/docs/manual/troubleshooting.tex
@@ -739,6 +739,8 @@ If you use the bash shell, put the following command in your
 in the JRE rather than in the JDK, but you need the JDK installed to build
 the Checker Framework anyway.)
 % Can someone give a simpler command?
+% Command taken from:
+%   https://github.com/typetools/checker-framework/blob/master/checker/bin-devel/build.sh#L19
 %BEGIN LATEX
 \begin{smaller}
 %END LATEX

--- a/docs/manual/troubleshooting.tex
+++ b/docs/manual/troubleshooting.tex
@@ -743,7 +743,7 @@ the Checker Framework anyway.)
 \begin{smaller}
 %END LATEX
 \begin{Verbatim}
-  export JAVA_HOME=${JAVA_HOME:-$(dirname $(dirname $(dirname $(readlink -f $(/usr/bin/which java)))))}
+  export JAVA_HOME=${JAVA_HOME:-$(dirname "$(dirname "$(readlink -f "$(which javac)")")")}
 \end{Verbatim}
 %BEGIN LATEX
 \end{smaller}


### PR DESCRIPTION
When setting up the system, I noticed an outdated command in the CF manual which didn't determine `JAVA_HOME` correctly for Ubuntu/Linux.