### PR TITLE
Improve dataflow analysis to fix issue #3275 and #3281

### DIFF
--- a/checker/tests/nullness/flow/Issue3275.java
+++ b/checker/tests/nullness/flow/Issue3275.java
@@ -1,0 +1,27 @@
+// Test case for Issue 3275:
+// https://github.com/typetools/checker-framework/issues/3275
+
+import org.checkerframework.checker.nullness.qual.Nullable;
+
+class Bug {
+    void foo(@Nullable Object obj) {
+        if ((obj != null) == false) {
+            // :: (dereference.of.nullable)
+            obj.toString();
+        }
+    }
+
+    void bar(@Nullable Object obj) {
+        if (!(obj == null) == false) {
+            // :: (dereference.of.nullable)
+            obj.toString();
+        }
+    }
+
+    void baz(@Nullable Object obj) {
+        if ((obj == null) == true) {
+            // :: (dereference.of.nullable)
+            obj.toString();
+        }
+    }
+}

--- a/checker/tests/nullness/flow/Issue3281.java
+++ b/checker/tests/nullness/flow/Issue3281.java
@@ -1,0 +1,16 @@
+// Test case for Issue 3281:
+// https://github.com/typetools/checker-framework/issues/3281
+
+import java.util.regex.Pattern;
+import org.checkerframework.checker.regex.RegexUtil;
+
+public class Issue3281 {
+
+    void bar(String s) {
+        RegexUtil.isRegex(s);
+        if (true) {
+            // :: error: (argument.type.incompatible)
+            Pattern.compile(s);
+        }
+    }
+}

--- a/dataflow/src/main/java/org/checkerframework/dataflow/cfg/CFGBuilder.java
+++ b/dataflow/src/main/java/org/checkerframework/dataflow/cfg/CFGBuilder.java
@@ -4040,15 +4040,20 @@ public class CFGBuilder {
             // basic block for the condition
             unbox(scan(tree.getCondition(), p));
 
+            // Determine whether the loop condition has the constant value true or constant value
+            // false, according to the compiler logic.
             boolean isCondConstTrue = TreeUtils.isExprConstTrue(tree.getCondition());
             boolean isCondConstFalse = TreeUtils.isExprConstFalse(tree.getCondition());
             if (!isCondConstTrue && !isCondConstFalse) {
+                // If the loop condition has neither the constant value true nor constant value
+                // false, the control flow is split into two branches.
                 ConditionalJump cjump = new ConditionalJump(thenEntry, elseEntry);
                 extendWithExtendedNode(cjump);
             }
 
             if (!isCondConstFalse) {
-                // then branch
+                // The condition does not have the constant value false, so the then branch is
+                // preserved.
                 addLabelForNextNode(thenEntry);
                 StatementTree thenStatement = tree.getThenStatement();
                 scan(thenStatement, p);
@@ -4056,7 +4061,8 @@ public class CFGBuilder {
             }
 
             if (!isCondConstTrue) {
-                // else branch
+                // The condition does not have the constant value true, so the else branch is
+                // preserved.
                 addLabelForNextNode(elseEntry);
                 StatementTree elseStatement = tree.getElseStatement();
                 if (elseStatement != null) {

--- a/javacutil/src/main/java/org/checkerframework/javacutil/TreeUtils.java
+++ b/javacutil/src/main/java/org/checkerframework/javacutil/TreeUtils.java
@@ -1394,9 +1394,11 @@ public final class TreeUtils {
     }
 
     /**
-     * * Determine whether an expression {@link ExpressionTree} has the constant value true,
-     * according * to the compiler logic. * * @param node the expression to be checked. * @return
-     * true if {@code node} has the constant value true.
+     * Determine whether an expression {@link ExpressionTree} has the constant value true, according
+     * to the compiler logic.
+     *
+     * @param node the expression to be checked
+     * @return true if {@code node} has the constant value true
      */
     public static boolean isExprConstTrue(final ExpressionTree node) {
         assert node instanceof JCExpression;
@@ -1421,9 +1423,11 @@ public final class TreeUtils {
     }
 
     /**
-     * * Determine whether an expression {@link ExpressionTree} has the constant value false,
-     * according * to the compiler logic. * * @param node the expression to be checked. * @return
-     * true if {@code node} has the constant value false.
+     * Determine whether an expression {@link ExpressionTree} has the constant value false,
+     * according to the compiler logic.
+     *
+     * @param node the expression to be checked
+     * @return true if {@code node} has the constant value false
      */
     public static boolean isExprConstFalse(final ExpressionTree node) {
         assert node instanceof JCExpression;

--- a/javacutil/src/main/java/org/checkerframework/javacutil/TreeUtils.java
+++ b/javacutil/src/main/java/org/checkerframework/javacutil/TreeUtils.java
@@ -37,6 +37,8 @@ import com.sun.tools.javac.processing.JavacProcessingEnvironment;
 import com.sun.tools.javac.tree.JCTree;
 import com.sun.tools.javac.tree.JCTree.JCAnnotatedType;
 import com.sun.tools.javac.tree.JCTree.JCAnnotation;
+import com.sun.tools.javac.tree.JCTree.JCBinary;
+import com.sun.tools.javac.tree.JCTree.JCExpression;
 import com.sun.tools.javac.tree.JCTree.JCExpressionStatement;
 import com.sun.tools.javac.tree.JCTree.JCLambda;
 import com.sun.tools.javac.tree.JCTree.JCLambda.ParameterKind;
@@ -1389,5 +1391,59 @@ public final class TreeUtils {
     public static boolean isImplicitlyTypedLambda(Tree tree) {
         return tree.getKind() == Kind.LAMBDA_EXPRESSION
                 && ((JCLambda) tree).paramKind == ParameterKind.IMPLICIT;
+    }
+
+    /**
+     * * Determine whether an expression {@link ExpressionTree} has the constant value true,
+     * according * to the compiler logic. * * @param node the expression to be checked. * @return
+     * true if {@code node} has the constant value true.
+     */
+    public static boolean isExprConstTrue(final ExpressionTree node) {
+        assert node instanceof JCExpression;
+        if (((JCExpression) node).type.isTrue()) {
+            return true;
+        }
+        ExpressionTree tree = TreeUtils.withoutParens(node);
+        if (tree instanceof JCTree.JCBinary) {
+            JCBinary binTree = (JCBinary) tree;
+            JCExpression ltree = binTree.lhs;
+            JCExpression rtree = binTree.rhs;
+            switch (binTree.getTag()) {
+                case AND:
+                    return isExprConstTrue(ltree) && isExprConstTrue(rtree);
+                case OR:
+                    return isExprConstTrue(ltree) || isExprConstTrue(rtree);
+                default:
+                    break;
+            }
+        }
+        return false;
+    }
+
+    /**
+     * * Determine whether an expression {@link ExpressionTree} has the constant value false,
+     * according * to the compiler logic. * * @param node the expression to be checked. * @return
+     * true if {@code node} has the constant value false.
+     */
+    public static boolean isExprConstFalse(final ExpressionTree node) {
+        assert node instanceof JCExpression;
+        if (((JCExpression) node).type.isFalse()) {
+            return true;
+        }
+        ExpressionTree tree = TreeUtils.withoutParens(node);
+        if (tree instanceof JCTree.JCBinary) {
+            JCBinary binTree = (JCBinary) tree;
+            JCExpression ltree = binTree.lhs;
+            JCExpression rtree = binTree.rhs;
+            switch (binTree.getTag()) {
+                case AND:
+                    return isExprConstFalse(ltree) || isExprConstFalse(rtree);
+                case OR:
+                    return isExprConstFalse(ltree) && isExprConstFalse(rtree);
+                default:
+                    break;
+            }
+        }
+        return false;
     }
 }


### PR DESCRIPTION
- To fix https://github.com/typetools/checker-framework/issues/3281, check whether the if condition has the constant value true or the constant value false. If so, preserve only one of the then branch and else branch accordingly.

- To fix https://github.com/typetools/checker-framework/issues/3275, treat condition shaped `expr == false` and `expr != true`  the same way as `ConditionalNotNode`.