### PR TITLE
Alternative solution for issue 3281 

### DIFF
--- a/checker/tests/regex/Issue3281.java
+++ b/checker/tests/regex/Issue3281.java
@@ -1,0 +1,16 @@
+// Test case for Issue 3281:
+// https://github.com/typetools/checker-framework/issues/3281
+
+import java.util.regex.Pattern;
+import org.checkerframework.checker.regex.RegexUtil;
+
+public class Issue3281 {
+
+    void bar(String s) {
+        RegexUtil.isRegex(s);
+        if (true) {
+            // :: error: (argument.type.incompatible)
+            Pattern.compile(s);
+        }
+    }
+}


### PR DESCRIPTION
This is an alternative for [PR#151](https://github.com/opprop/checker-framework/pull/151) to fix https://github.com/typetools/checker-framework/issues/3281 by adding auxiliary assignment for expression statements followed by an if-statement, which causes merging of store branches during dataflow analysis.