### PR TITLE
Merge stores after every expression statement

### DIFF
--- a/checker/tests/regex/Issue3281.java
+++ b/checker/tests/regex/Issue3281.java
@@ -1,0 +1,16 @@
+// Test case for Issue 3281:
+// https://github.com/typetools/checker-framework/issues/3281
+
+import java.util.regex.Pattern;
+import org.checkerframework.checker.regex.RegexUtil;
+
+public class Issue3281 {
+
+    void bar(String s) {
+        RegexUtil.isRegex(s);
+        if (true) {
+            // :: error: (argument.type.incompatible)
+            Pattern.compile(s);
+        }
+    }
+}

--- a/dataflow/src/main/java/org/checkerframework/dataflow/cfg/CFGBuilder.java
+++ b/dataflow/src/main/java/org/checkerframework/dataflow/cfg/CFGBuilder.java
@@ -3364,16 +3364,6 @@ public class CFGBuilder {
 
         @Override
         public Node visitBlock(BlockTree tree, Void p) {
-            /*
-              List<? extends StatementTree> statements = tree.getStatements();
-              // Collect all expression satatments that are followed by a if statment
-              for (int i = 0; i < statements.size() - 1; i++) {
-                  if (statements.get(i).getKind() == Kind.EXPRESSION_STATEMENT
-                          && statements.get(i + 1).getKind() == Kind.IF) {
-                      statementBeforeIf.add(statements.get(i));
-                  }
-              }
-            */
             for (StatementTree n : tree.getStatements()) {
                 scan(n, null);
             }
@@ -3630,10 +3620,9 @@ public class CFGBuilder {
 
         @Override
         public Node visitExpressionStatement(ExpressionStatementTree tree, Void p) {
-            // if (statementBeforeIf.contains(tree)) {
-            // For an expression statment followed by an if-statment, create a local variable
-            // and assign the expression to that local variable, which would lead merging of the
-            // two store branches during dataflow analysis.
+            // For every expression statement, create a local variable and assign the expression to
+            // that local variable, which would lead to merging of the two stores during dataflow
+            // analysis.
             String name = uniqueName("mergeStoreBeforeIf");
             Element owner = findOwner();
             ExpressionTree initializer = tree.getExpression();
@@ -3641,10 +3630,6 @@ public class CFGBuilder {
                     treeBuilder.buildVariableDecl(
                             TreeUtils.typeOf(initializer), name, owner, initializer);
             return scan(auxillaryVariable, p);
-
-            /* } else {
-            return scan(tree.getExpression(), p);
-            } */
         }
 
         @Override

--- a/dataflow/src/main/java/org/checkerframework/dataflow/cfg/CFGBuilder.java
+++ b/dataflow/src/main/java/org/checkerframework/dataflow/cfg/CFGBuilder.java
@@ -3364,14 +3364,16 @@ public class CFGBuilder {
 
         @Override
         public Node visitBlock(BlockTree tree, Void p) {
-            List<? extends StatementTree> statements = tree.getStatements();
-            // Collect all expression satatments that are followed by a if statment
-            for (int i = 0; i < statements.size() - 1; i++) {
-                if (statements.get(i).getKind() == Kind.EXPRESSION_STATEMENT
-                        && statements.get(i + 1).getKind() == Kind.IF) {
-                    statementBeforeIf.add(statements.get(i));
-                }
-            }
+            /*
+              List<? extends StatementTree> statements = tree.getStatements();
+              // Collect all expression satatments that are followed by a if statment
+              for (int i = 0; i < statements.size() - 1; i++) {
+                  if (statements.get(i).getKind() == Kind.EXPRESSION_STATEMENT
+                          && statements.get(i + 1).getKind() == Kind.IF) {
+                      statementBeforeIf.add(statements.get(i));
+                  }
+              }
+            */
             for (StatementTree n : tree.getStatements()) {
                 scan(n, null);
             }
@@ -3628,21 +3630,21 @@ public class CFGBuilder {
 
         @Override
         public Node visitExpressionStatement(ExpressionStatementTree tree, Void p) {
-            if (statementBeforeIf.contains(tree)) {
-                // For an expression statment followed by an if-statment, create a local variable
-                // and assign the expression to that local variable, which would lead merging of the
-                // two store branches during dataflow analysis.
-                String name = uniqueName("mergeStoreBeforeIf");
-                Element owner = findOwner();
-                ExpressionTree initializer = tree.getExpression();
-                VariableTree auxillaryVariable =
-                        treeBuilder.buildVariableDecl(
-                                TreeUtils.typeOf(initializer), name, owner, initializer);
-                return scan(auxillaryVariable, p);
+            // if (statementBeforeIf.contains(tree)) {
+            // For an expression statment followed by an if-statment, create a local variable
+            // and assign the expression to that local variable, which would lead merging of the
+            // two store branches during dataflow analysis.
+            String name = uniqueName("mergeStoreBeforeIf");
+            Element owner = findOwner();
+            ExpressionTree initializer = tree.getExpression();
+            VariableTree auxillaryVariable =
+                    treeBuilder.buildVariableDecl(
+                            TreeUtils.typeOf(initializer), name, owner, initializer);
+            return scan(auxillaryVariable, p);
 
-            } else {
-                return scan(tree.getExpression(), p);
-            }
+            /* } else {
+            return scan(tree.getExpression(), p);
+            } */
         }
 
         @Override


### PR DESCRIPTION
This PR is an alternative solution to [PR#154](https://github.com/opprop/checker-framework/pull/154). Instead of merging stores only after expression statements followed by `if`, it merges stores after expression statement by making it the initializer to an auxiliary variable.