### PR TITLE
Invoke correct CFI .ci-build.sh script

### DIFF
--- a/checker/bin-devel/test-cf-inference.sh
+++ b/checker/bin-devel/test-cf-inference.sh
@@ -20,4 +20,4 @@ source "$SCRIPTDIR"/build.sh
 
 export AFU="${AFU:-$(cd ../annotation-tools/annotation-file-utilities >/dev/null 2>&1 && pwd -P)}"
 export PATH=$AFU/scripts:$PATH
-(cd ../checker-framework-inference && ./.travis-build.sh)
+(cd ../checker-framework-inference && ./.ci-build.sh)


### PR DESCRIPTION
The inference CI has been moved to github actions, with `.travis-build.sh` being renamed `.ci-build.sh`.