### PR TITLE
Publish build artifacts to azure pipeline

### DIFF
--- a/azure-pipelines.yml
+++ b/azure-pipelines.yml
@@ -19,6 +19,11 @@ jobs:
     fetchDepth: 25
   - bash: ./checker/bin-devel/test-cftests-all.sh
     displayName: test-cftests-all.sh
+  - task: PublishPipelineArtifact@1
+    inputs:
+      targetPath: ./checker/dist
+      artifactName: cf_jdk8
+      artifactType: pipeline
 - job: all_tests_jdk11
   pool:
     vmImage: 'ubuntu-latest'
@@ -28,6 +33,11 @@ jobs:
     fetchDepth: 25
   - bash: ./checker/bin-devel/test-cftests-all.sh
     displayName: test-cftests-all.sh
+  - task: PublishPipelineArtifact@1
+    inputs:
+      targetPath: ./checker/dist
+      artifactName: cf_jdk11
+      artifactType: pipeline
 - job: misc_jdk11
   pool:
     vmImage: 'ubuntu-latest'


### PR DESCRIPTION
Once tests passed, build artifacts will be published to the corresponding pipeline, and we should be able to download the artifacts manually.

![image](https://user-images.githubusercontent.com/12403206/121949132-1e8de880-cd26-11eb-8f1f-bf229dc3ad7e.png)

![image](https://user-images.githubusercontent.com/12403206/121949153-26e62380-cd26-11eb-8fa8-3c1d90d3c2a8.png)
