### PR TITLE
Fix visitor rule for invalid polymorphic qualifier use

### DIFF
--- a/framework/src/main/java/org/checkerframework/common/basetype/BaseTypeVisitor.java
+++ b/framework/src/main/java/org/checkerframework/common/basetype/BaseTypeVisitor.java
@@ -720,7 +720,7 @@ public class BaseTypeVisitor<Factory extends GenericAnnotatedTypeFactory<?, ?, ?
             }
 
             for (AnnotationMirror poly : polys) {
-                if (type.hasAnnotationRelaxed(poly)) {
+                if (type.hasAnnotation(poly)) {
                     return Collections.singletonList(
                             new DiagMessage(Kind.ERROR, "invalid.polymorphic.qualifier.use", poly));
                 }


### PR DESCRIPTION
`hasAnnotationRelaxed` only checks whether the name of the annotation matches the name of the poly annotation. This PR proposes to use `hasAnnotation` instead because we could have annotations with a poly value, and `hasAnnotation` also compares the values of an annotation.

Note: This PR is related to https://github.com/opprop/ontology/pull/58 since it introduces the polymorphic annotation `@Ontology(values={POLY})`