### PR TITLE
Apply String declaration bounds to String conversion nodes

### DIFF
--- a/checker/src/test/java/org/checkerframework/checker/test/junit/CalledMethodsAutoValueTest.java
+++ b/checker/src/test/java/org/checkerframework/checker/test/junit/CalledMethodsAutoValueTest.java
@@ -24,7 +24,6 @@ public class CalledMethodsAutoValueTest extends CheckerFrameworkPerDirectoryTest
                         CalledMethodsChecker.class.getName()),
                 "calledmethods-autovalue",
                 Collections.emptyList(),
-                "-Anomsgtext",
                 "-nowarn");
     }
 

--- a/checker/src/test/java/org/checkerframework/checker/test/junit/CalledMethodsDisableReturnsReceiverTest.java
+++ b/checker/src/test/java/org/checkerframework/checker/test/junit/CalledMethodsDisableReturnsReceiverTest.java
@@ -14,7 +14,6 @@ public class CalledMethodsDisableReturnsReceiverTest extends CheckerFrameworkPer
                 testFiles,
                 CalledMethodsChecker.class,
                 "calledmethods-disablereturnsreceiver",
-                "-Anomsgtext",
                 "-AdisableReturnsReceiver",
                 "-encoding",
                 "UTF-8");

--- a/checker/src/test/java/org/checkerframework/checker/test/junit/CalledMethodsDisableframeworksTest.java
+++ b/checker/src/test/java/org/checkerframework/checker/test/junit/CalledMethodsDisableframeworksTest.java
@@ -23,7 +23,6 @@ public class CalledMethodsDisableframeworksTest extends CheckerFrameworkPerDirec
                         CalledMethodsChecker.class.getName()),
                 "calledmethods-disableframeworks",
                 Collections.emptyList(),
-                "-Anomsgtext",
                 "-AdisableBuilderFrameworkSupports=autovalue,lombok",
                 // The next option is so that we can run the usevaluechecker tests under this
                 // configuration.

--- a/checker/src/test/java/org/checkerframework/checker/test/junit/CalledMethodsLombokTest.java
+++ b/checker/src/test/java/org/checkerframework/checker/test/junit/CalledMethodsLombokTest.java
@@ -14,7 +14,6 @@ public class CalledMethodsLombokTest extends CheckerFrameworkPerDirectoryTest {
                 testFiles,
                 CalledMethodsChecker.class,
                 "calledmethods-delomboked",
-                "-Anomsgtext",
                 "-nowarn",
                 "-AsuppressWarnings=type.anno.before.modifier");
     }

--- a/checker/src/test/java/org/checkerframework/checker/test/junit/CalledMethodsNoDelombokTest.java
+++ b/checker/src/test/java/org/checkerframework/checker/test/junit/CalledMethodsNoDelombokTest.java
@@ -32,7 +32,6 @@ public class CalledMethodsNoDelombokTest extends CheckerFrameworkPerDirectoryTes
                 testFiles,
                 org.checkerframework.checker.calledmethods.CalledMethodsChecker.class,
                 "lombok",
-                "-Anomsgtext",
                 "-nowarn");
     }
 

--- a/checker/src/test/java/org/checkerframework/checker/test/junit/CalledMethodsTest.java
+++ b/checker/src/test/java/org/checkerframework/checker/test/junit/CalledMethodsTest.java
@@ -14,7 +14,6 @@ public class CalledMethodsTest extends CheckerFrameworkPerDirectoryTest {
                 testFiles,
                 CalledMethodsChecker.class,
                 "calledmethods",
-                "-Anomsgtext",
                 "-nowarn",
                 "-encoding",
                 "UTF-8");

--- a/checker/src/test/java/org/checkerframework/checker/test/junit/CalledMethodsUseValueCheckerTest.java
+++ b/checker/src/test/java/org/checkerframework/checker/test/junit/CalledMethodsUseValueCheckerTest.java
@@ -13,7 +13,6 @@ public class CalledMethodsUseValueCheckerTest extends CheckerFrameworkPerDirecto
                 testFiles,
                 CalledMethodsChecker.class,
                 "calledmethods-usevaluechecker",
-                "-Anomsgtext",
                 "-AuseValueChecker",
                 "-nowarn");
     }

--- a/checker/src/test/java/org/checkerframework/checker/test/junit/CompilerMessagesTest.java
+++ b/checker/src/test/java/org/checkerframework/checker/test/junit/CompilerMessagesTest.java
@@ -19,7 +19,6 @@ public class CompilerMessagesTest extends CheckerFrameworkPerDirectoryTest {
                 testFiles,
                 org.checkerframework.checker.compilermsgs.CompilerMessagesChecker.class,
                 "compilermsg",
-                "-Anomsgtext",
                 "-Apropfiles=tests/compilermsg/compiler.properties");
     }
 

--- a/checker/src/test/java/org/checkerframework/checker/test/junit/DisbarUseTest.java
+++ b/checker/src/test/java/org/checkerframework/checker/test/junit/DisbarUseTest.java
@@ -19,7 +19,6 @@ public class DisbarUseTest extends CheckerFrameworkPerDirectoryTest {
                 testFiles,
                 DisbarUseChecker.class,
                 "disbaruse-records",
-                "-Anomsgtext",
                 "-Astubs=tests/disbaruse-records",
                 "-AstubWarnIfNotFound");
     }

--- a/checker/src/test/java/org/checkerframework/checker/test/junit/FenumSwingTest.java
+++ b/checker/src/test/java/org/checkerframework/checker/test/junit/FenumSwingTest.java
@@ -18,7 +18,6 @@ public class FenumSwingTest extends CheckerFrameworkPerDirectoryTest {
                 testFiles,
                 org.checkerframework.checker.fenum.FenumChecker.class,
                 "fenum",
-                "-Anomsgtext",
                 "-Aquals=org.checkerframework.checker.fenum.qual.SwingVerticalOrientation,org.checkerframework.checker.fenum.qual.SwingHorizontalOrientation,org.checkerframework.checker.fenum.qual.SwingBoxOrientation,org.checkerframework.checker.fenum.qual.SwingCompassDirection,org.checkerframework.checker.fenum.qual.SwingElementOrientation,org.checkerframework.checker.fenum.qual.SwingTextOrientation");
         // TODO: check all qualifiers
     }

--- a/checker/src/test/java/org/checkerframework/checker/test/junit/FenumTest.java
+++ b/checker/src/test/java/org/checkerframework/checker/test/junit/FenumTest.java
@@ -14,11 +14,7 @@ public class FenumTest extends CheckerFrameworkPerDirectoryTest {
      * @param testFiles the files containing test code, which will be type-checked
      */
     public FenumTest(List<File> testFiles) {
-        super(
-                testFiles,
-                org.checkerframework.checker.fenum.FenumChecker.class,
-                "fenum",
-                "-Anomsgtext");
+        super(testFiles, org.checkerframework.checker.fenum.FenumChecker.class, "fenum");
     }
 
     @Parameters

--- a/checker/src/test/java/org/checkerframework/checker/test/junit/FormatterLubGlbCheckerTest.java
+++ b/checker/src/test/java/org/checkerframework/checker/test/junit/FormatterLubGlbCheckerTest.java
@@ -19,12 +19,7 @@ public class FormatterLubGlbCheckerTest extends CheckerFrameworkPerDirectoryTest
      * @param testFiles the files containing test code, which will be type-checked
      */
     public FormatterLubGlbCheckerTest(List<File> testFiles) {
-        super(
-                testFiles,
-                FormatterLubGlbChecker.class,
-                "",
-                "-Anomsgtext",
-                "-AcheckPurityAnnotations");
+        super(testFiles, FormatterLubGlbChecker.class, "", "-AcheckPurityAnnotations");
     }
 
     @Parameters

--- a/checker/src/test/java/org/checkerframework/checker/test/junit/FormatterTest.java
+++ b/checker/src/test/java/org/checkerframework/checker/test/junit/FormatterTest.java
@@ -16,8 +16,7 @@ public class FormatterTest extends CheckerFrameworkPerDirectoryTest {
         super(
                 testFiles,
                 org.checkerframework.checker.formatter.FormatterChecker.class,
-                "formatter",
-                "-Anomsgtext");
+                "formatter");
     }
 
     @Parameters

--- a/checker/src/test/java/org/checkerframework/checker/test/junit/FormatterUncheckedDefaultsTest.java
+++ b/checker/src/test/java/org/checkerframework/checker/test/junit/FormatterUncheckedDefaultsTest.java
@@ -17,7 +17,6 @@ public class FormatterUncheckedDefaultsTest extends CheckerFrameworkPerDirectory
                 testFiles,
                 org.checkerframework.checker.formatter.FormatterChecker.class,
                 "formatter",
-                "-Anomsgtext",
                 "-AuseConservativeDefaultsForUncheckedCode=-source,bytecode");
     }
 

--- a/checker/src/test/java/org/checkerframework/checker/test/junit/GuiEffectTest.java
+++ b/checker/src/test/java/org/checkerframework/checker/test/junit/GuiEffectTest.java
@@ -17,8 +17,7 @@ public class GuiEffectTest extends CheckerFrameworkPerDirectoryTest {
         super(
                 testFiles,
                 org.checkerframework.checker.guieffect.GuiEffectChecker.class,
-                "guieffect",
-                "-Anomsgtext");
+                "guieffect");
         // , "-Alint=debugSpew");
     }
 

--- a/checker/src/test/java/org/checkerframework/checker/test/junit/I18nFormatterLubGlbCheckerTest.java
+++ b/checker/src/test/java/org/checkerframework/checker/test/junit/I18nFormatterLubGlbCheckerTest.java
@@ -19,12 +19,7 @@ public class I18nFormatterLubGlbCheckerTest extends CheckerFrameworkPerDirectory
      * @param testFiles the files containing test code, which will be type-checked
      */
     public I18nFormatterLubGlbCheckerTest(List<File> testFiles) {
-        super(
-                testFiles,
-                I18nFormatterLubGlbChecker.class,
-                "",
-                "-Anomsgtext",
-                "-AcheckPurityAnnotations");
+        super(testFiles, I18nFormatterLubGlbChecker.class, "", "-AcheckPurityAnnotations");
     }
 
     @Parameters

--- a/checker/src/test/java/org/checkerframework/checker/test/junit/I18nFormatterTest.java
+++ b/checker/src/test/java/org/checkerframework/checker/test/junit/I18nFormatterTest.java
@@ -17,8 +17,7 @@ public class I18nFormatterTest extends CheckerFrameworkPerDirectoryTest {
         super(
                 testFiles,
                 org.checkerframework.checker.i18nformatter.I18nFormatterChecker.class,
-                "i18n-formatter",
-                "-Anomsgtext");
+                "i18n-formatter");
     }
 
     @Parameters

--- a/checker/src/test/java/org/checkerframework/checker/test/junit/I18nFormatterUncheckedDefaultsTest.java
+++ b/checker/src/test/java/org/checkerframework/checker/test/junit/I18nFormatterUncheckedDefaultsTest.java
@@ -18,7 +18,6 @@ public class I18nFormatterUncheckedDefaultsTest extends CheckerFrameworkPerDirec
                 testFiles,
                 org.checkerframework.checker.i18nformatter.I18nFormatterChecker.class,
                 "i18n-formatter",
-                "-Anomsgtext",
                 "-AuseConservativeDefaultsForUncheckedCode=-source,bytecode");
     }
 

--- a/checker/src/test/java/org/checkerframework/checker/test/junit/I18nTest.java
+++ b/checker/src/test/java/org/checkerframework/checker/test/junit/I18nTest.java
@@ -14,11 +14,7 @@ public class I18nTest extends CheckerFrameworkPerDirectoryTest {
      * @param testFiles the files containing test code, which will be type-checked
      */
     public I18nTest(List<File> testFiles) {
-        super(
-                testFiles,
-                org.checkerframework.checker.i18n.I18nChecker.class,
-                "i18n",
-                "-Anomsgtext");
+        super(testFiles, org.checkerframework.checker.i18n.I18nChecker.class, "i18n");
     }
 
     @Parameters

--- a/checker/src/test/java/org/checkerframework/checker/test/junit/I18nUncheckedDefaultsTest.java
+++ b/checker/src/test/java/org/checkerframework/checker/test/junit/I18nUncheckedDefaultsTest.java
@@ -18,7 +18,6 @@ public class I18nUncheckedDefaultsTest extends CheckerFrameworkPerDirectoryTest 
                 testFiles,
                 org.checkerframework.checker.i18n.I18nChecker.class,
                 "i18n",
-                "-Anomsgtext",
                 "-AuseConservativeDefaultsForUncheckedCode=-source,bytecode");
     }
 

--- a/checker/src/test/java/org/checkerframework/checker/test/junit/IndexTest.java
+++ b/checker/src/test/java/org/checkerframework/checker/test/junit/IndexTest.java
@@ -15,11 +15,7 @@ public class IndexTest extends CheckerFrameworkPerDirectoryTest {
      * @param testFiles the files containing test code, which will be type-checked
      */
     public IndexTest(List<File> testFiles) {
-        super(
-                testFiles,
-                org.checkerframework.checker.index.IndexChecker.class,
-                "index",
-                "-Anomsgtext");
+        super(testFiles, org.checkerframework.checker.index.IndexChecker.class, "index");
     }
 
     @Parameters

--- a/checker/src/test/java/org/checkerframework/checker/test/junit/InterningTest.java
+++ b/checker/src/test/java/org/checkerframework/checker/test/junit/InterningTest.java
@@ -18,8 +18,7 @@ public class InterningTest extends CheckerFrameworkPerDirectoryTest {
         super(
                 testFiles,
                 org.checkerframework.checker.interning.InterningChecker.class,
-                "interning",
-                "-Anomsgtext");
+                "interning");
     }
 
     @Parameters

--- a/checker/src/test/java/org/checkerframework/checker/test/junit/LockSafeDefaultsTest.java
+++ b/checker/src/test/java/org/checkerframework/checker/test/junit/LockSafeDefaultsTest.java
@@ -19,8 +19,7 @@ public class LockSafeDefaultsTest extends CheckerFrameworkPerDirectoryTest {
                 testFiles,
                 org.checkerframework.checker.lock.LockChecker.class,
                 "lock",
-                "-AuseConservativeDefaultsForUncheckedCode=source",
-                "-Anomsgtext");
+                "-AuseConservativeDefaultsForUncheckedCode=source");
     }
 
     @Parameters

--- a/checker/src/test/java/org/checkerframework/checker/test/junit/LockTest.java
+++ b/checker/src/test/java/org/checkerframework/checker/test/junit/LockTest.java
@@ -14,11 +14,7 @@ public class LockTest extends CheckerFrameworkPerDirectoryTest {
      * @param testFiles the files containing test code, which will be type-checked
      */
     public LockTest(List<File> testFiles) {
-        super(
-                testFiles,
-                org.checkerframework.checker.lock.LockChecker.class,
-                "lock",
-                "-Anomsgtext");
+        super(testFiles, org.checkerframework.checker.lock.LockChecker.class, "lock");
     }
 
     @Parameters

--- a/checker/src/test/java/org/checkerframework/checker/test/junit/MustCallNoLightweightOwnershipTest.java
+++ b/checker/src/test/java/org/checkerframework/checker/test/junit/MustCallNoLightweightOwnershipTest.java
@@ -12,7 +12,6 @@ public class MustCallNoLightweightOwnershipTest extends CheckerFrameworkPerDirec
                 testFiles,
                 org.checkerframework.checker.mustcall.MustCallChecker.class,
                 "mustcall-nolightweightownership",
-                "-Anomsgtext",
                 "-AnoLightweightOwnership",
                 // "-AstubDebug");
                 "-nowarn");

--- a/checker/src/test/java/org/checkerframework/checker/test/junit/MustCallTest.java
+++ b/checker/src/test/java/org/checkerframework/checker/test/junit/MustCallTest.java
@@ -12,7 +12,6 @@ public class MustCallTest extends CheckerFrameworkPerDirectoryTest {
                 testFiles,
                 org.checkerframework.checker.mustcall.MustCallChecker.class,
                 "mustcall",
-                "-Anomsgtext",
                 // "-AstubDebug");
                 "-nowarn");
     }

--- a/checker/src/test/java/org/checkerframework/checker/test/junit/NestedAggregateCheckerTest.java
+++ b/checker/src/test/java/org/checkerframework/checker/test/junit/NestedAggregateCheckerTest.java
@@ -19,12 +19,7 @@ public class NestedAggregateCheckerTest extends CheckerFrameworkPerDirectoryTest
      * @param testFiles the files containing test code, which will be type-checked
      */
     public NestedAggregateCheckerTest(List<File> testFiles) {
-        super(
-                testFiles,
-                NestedAggregateChecker.class,
-                "",
-                "-Anomsgtext",
-                "-AcheckPurityAnnotations");
+        super(testFiles, NestedAggregateChecker.class, "", "-AcheckPurityAnnotations");
     }
 
     @Parameters

--- a/checker/src/test/java/org/checkerframework/checker/test/junit/NullnessAssertsTest.java
+++ b/checker/src/test/java/org/checkerframework/checker/test/junit/NullnessAssertsTest.java
@@ -25,7 +25,6 @@ public class NullnessAssertsTest extends CheckerFrameworkPerDirectoryTest {
                 "nullness",
                 "-AcheckPurityAnnotations",
                 "-AassumeAssertionsAreEnabled",
-                "-Anomsgtext",
                 "-Xlint:deprecation",
                 "-Alint=soundArrayCreationNullness,"
                         + NullnessChecker.LINT_REDUNDANTNULLCOMPARISON);

--- a/checker/src/test/java/org/checkerframework/checker/test/junit/NullnessAssumeAssertionsAreDisabledTest.java
+++ b/checker/src/test/java/org/checkerframework/checker/test/junit/NullnessAssumeAssertionsAreDisabledTest.java
@@ -20,7 +20,6 @@ public class NullnessAssumeAssertionsAreDisabledTest extends CheckerFrameworkPer
                 org.checkerframework.checker.nullness.NullnessChecker.class,
                 "nullness",
                 "-AassumeAssertionsAreDisabled",
-                "-Anomsgtext",
                 "-Xlint:deprecation");
     }
 

--- a/checker/src/test/java/org/checkerframework/checker/test/junit/NullnessAssumeKeyForTest.java
+++ b/checker/src/test/java/org/checkerframework/checker/test/junit/NullnessAssumeKeyForTest.java
@@ -25,7 +25,6 @@ public class NullnessAssumeKeyForTest extends CheckerFrameworkPerDirectoryTest {
                 "nullness",
                 "-AcheckPurityAnnotations",
                 "-AassumeKeyFor",
-                "-Anomsgtext",
                 "-Xlint:deprecation",
                 "-Alint=soundArrayCreationNullness,"
                         + NullnessChecker.LINT_REDUNDANTNULLCOMPARISON);

--- a/checker/src/test/java/org/checkerframework/checker/test/junit/NullnessCheckCastElementTypeTest.java
+++ b/checker/src/test/java/org/checkerframework/checker/test/junit/NullnessCheckCastElementTypeTest.java
@@ -19,8 +19,7 @@ public class NullnessCheckCastElementTypeTest extends CheckerFrameworkPerDirecto
                 testFiles,
                 org.checkerframework.checker.nullness.NullnessChecker.class,
                 "nullness",
-                "-AcheckCastElementType",
-                "-Anomsgtext");
+                "-AcheckCastElementType");
     }
 
     @Parameters

--- a/checker/src/test/java/org/checkerframework/checker/test/junit/NullnessConcurrentTest.java
+++ b/checker/src/test/java/org/checkerframework/checker/test/junit/NullnessConcurrentTest.java
@@ -19,8 +19,7 @@ public class NullnessConcurrentTest extends CheckerFrameworkPerDirectoryTest {
                 testFiles,
                 org.checkerframework.checker.nullness.NullnessChecker.class,
                 "nullness",
-                "-AconcurrentSemantics",
-                "-Anomsgtext");
+                "-AconcurrentSemantics");
     }
 
     @Parameters

--- a/checker/src/test/java/org/checkerframework/checker/test/junit/NullnessGenericWildcardTest.java
+++ b/checker/src/test/java/org/checkerframework/checker/test/junit/NullnessGenericWildcardTest.java
@@ -29,8 +29,7 @@ public class NullnessGenericWildcardTest extends CheckerFrameworkPerDirectoryTes
                 "nullness",
                 // This test reads bytecode .class files created by NullnessGenericWildcardLibTest
                 "-cp",
-                "dist/checker.jar:tests/build/testclasses/",
-                "-Anomsgtext");
+                "dist/checker.jar:tests/build/testclasses/");
     }
 
     @Parameters

--- a/checker/src/test/java/org/checkerframework/checker/test/junit/NullnessInvariantArraysTest.java
+++ b/checker/src/test/java/org/checkerframework/checker/test/junit/NullnessInvariantArraysTest.java
@@ -19,8 +19,7 @@ public class NullnessInvariantArraysTest extends CheckerFrameworkPerDirectoryTes
                 testFiles,
                 org.checkerframework.checker.nullness.NullnessChecker.class,
                 "nullness",
-                "-AinvariantArrays",
-                "-Anomsgtext");
+                "-AinvariantArrays");
     }
 
     @Parameters

--- a/checker/src/test/java/org/checkerframework/checker/test/junit/NullnessJSpecifySamplesTest.java
+++ b/checker/src/test/java/org/checkerframework/checker/test/junit/NullnessJSpecifySamplesTest.java
@@ -41,8 +41,7 @@ public class NullnessJSpecifySamplesTest extends CheckerFrameworkPerDirectoryTes
                 testFiles,
                 org.checkerframework.checker.nullness.NullnessChecker.class,
                 "../../../jspecify/samples",
-                Collections.singletonList("../../jspecify/build/libs/jspecify-0.0.0-SNAPSHOT.jar"),
-                "-Anomsgtext");
+                Collections.singletonList("../../jspecify/build/libs/jspecify-0.0.0-SNAPSHOT.jar"));
     }
 
     @Parameters

--- a/checker/src/test/java/org/checkerframework/checker/test/junit/NullnessJavacErrorsTest.java
+++ b/checker/src/test/java/org/checkerframework/checker/test/junit/NullnessJavacErrorsTest.java
@@ -18,7 +18,6 @@ public class NullnessJavacErrorsTest extends CheckerFrameworkPerFileTest {
                 org.checkerframework.checker.nullness.NullnessChecker.class,
                 "nullness",
                 "-AcheckPurityAnnotations",
-                "-Anomsgtext",
                 "-Xlint:deprecation",
                 "-Alint=soundArrayCreationNullness,"
                         + NullnessChecker.LINT_REDUNDANTNULLCOMPARISON);

--- a/checker/src/test/java/org/checkerframework/checker/test/junit/NullnessJavadocTest.java
+++ b/checker/src/test/java/org/checkerframework/checker/test/junit/NullnessJavadocTest.java
@@ -19,8 +19,7 @@ public class NullnessJavadocTest extends CheckerFrameworkPerDirectoryTest {
                 testFiles,
                 org.checkerframework.checker.nullness.NullnessChecker.class,
                 "nullness",
-                toolsJarList(),
-                "-Anomsgtext");
+                toolsJarList());
     }
 
     /**

--- a/checker/src/test/java/org/checkerframework/checker/test/junit/NullnessNoDelombokTest.java
+++ b/checker/src/test/java/org/checkerframework/checker/test/junit/NullnessNoDelombokTest.java
@@ -31,7 +31,6 @@ public class NullnessNoDelombokTest extends CheckerFrameworkPerDirectoryTest {
                 testFiles,
                 org.checkerframework.checker.nullness.NullnessChecker.class,
                 "nullness-nodelombok",
-                "-Anomsgtext",
                 "-nowarn");
     }
 

--- a/checker/src/test/java/org/checkerframework/checker/test/junit/NullnessNullMarkedTest.java
+++ b/checker/src/test/java/org/checkerframework/checker/test/junit/NullnessNullMarkedTest.java
@@ -22,8 +22,7 @@ public class NullnessNullMarkedTest extends CheckerFrameworkPerDirectoryTest {
                 testFiles,
                 org.checkerframework.checker.nullness.NullnessChecker.class,
                 "nullness",
-                Collections.singletonList("../../jspecify/build/libs/jspecify-0.0.0-SNAPSHOT.jar"),
-                "-Anomsgtext");
+                Collections.singletonList("../../jspecify/build/libs/jspecify-0.0.0-SNAPSHOT.jar"));
     }
 
     @Parameters

--- a/checker/src/test/java/org/checkerframework/checker/test/junit/NullnessPermitClearPropertyTest.java
+++ b/checker/src/test/java/org/checkerframework/checker/test/junit/NullnessPermitClearPropertyTest.java
@@ -18,7 +18,6 @@ public class NullnessPermitClearPropertyTest extends CheckerFrameworkPerDirector
                 testFiles,
                 org.checkerframework.checker.nullness.NullnessChecker.class,
                 "nullness",
-                "-Anomsgtext",
                 "-Alint=permitClearProperty");
     }
 

--- a/checker/src/test/java/org/checkerframework/checker/test/junit/NullnessRecordsTest.java
+++ b/checker/src/test/java/org/checkerframework/checker/test/junit/NullnessRecordsTest.java
@@ -21,7 +21,6 @@ public class NullnessRecordsTest extends CheckerFrameworkPerDirectoryTest {
                 NullnessChecker.class,
                 "nullness-records",
                 "-AcheckPurityAnnotations",
-                "-Anomsgtext",
                 "-Xlint:deprecation");
     }
 

--- a/checker/src/test/java/org/checkerframework/checker/test/junit/NullnessReflectionTest.java
+++ b/checker/src/test/java/org/checkerframework/checker/test/junit/NullnessReflectionTest.java
@@ -19,8 +19,7 @@ public class NullnessReflectionTest extends CheckerFrameworkPerDirectoryTest {
                 testFiles,
                 org.checkerframework.checker.nullness.NullnessChecker.class,
                 "nullness",
-                "-AresolveReflection",
-                "-Anomsgtext");
+                "-AresolveReflection");
     }
 
     @Parameters

--- a/checker/src/test/java/org/checkerframework/checker/test/junit/NullnessSafeDefaultsBytecodeTest.java
+++ b/checker/src/test/java/org/checkerframework/checker/test/junit/NullnessSafeDefaultsBytecodeTest.java
@@ -19,8 +19,7 @@ public class NullnessSafeDefaultsBytecodeTest extends CheckerFrameworkPerDirecto
                 testFiles,
                 org.checkerframework.checker.nullness.NullnessChecker.class,
                 "nullness",
-                "-AuseConservativeDefaultsForUncheckedCode=bytecode",
-                "-Anomsgtext");
+                "-AuseConservativeDefaultsForUncheckedCode=bytecode");
     }
 
     @Parameters

--- a/checker/src/test/java/org/checkerframework/checker/test/junit/NullnessSafeDefaultsSourceCodeTest.java
+++ b/checker/src/test/java/org/checkerframework/checker/test/junit/NullnessSafeDefaultsSourceCodeTest.java
@@ -29,8 +29,7 @@ public class NullnessSafeDefaultsSourceCodeTest extends CheckerFrameworkPerDirec
                 "nullness",
                 "-AuseConservativeDefaultsForUncheckedCode=source",
                 "-cp",
-                "dist/checker.jar:tests/build/testclasses/",
-                "-Anomsgtext");
+                "dist/checker.jar:tests/build/testclasses/");
     }
 
     @Parameters

--- a/checker/src/test/java/org/checkerframework/checker/test/junit/NullnessSkipDefsTest.java
+++ b/checker/src/test/java/org/checkerframework/checker/test/junit/NullnessSkipDefsTest.java
@@ -19,7 +19,6 @@ public class NullnessSkipDefsTest extends CheckerFrameworkPerDirectoryTest {
                 testFiles,
                 org.checkerframework.checker.nullness.NullnessChecker.class,
                 "nullness",
-                "-Anomsgtext",
                 "-AskipDefs=SkipMe");
     }
 

--- a/checker/src/test/java/org/checkerframework/checker/test/junit/NullnessSkipUsesTest.java
+++ b/checker/src/test/java/org/checkerframework/checker/test/junit/NullnessSkipUsesTest.java
@@ -19,7 +19,6 @@ public class NullnessSkipUsesTest extends CheckerFrameworkPerDirectoryTest {
                 testFiles,
                 org.checkerframework.checker.nullness.NullnessChecker.class,
                 "nullness",
-                "-Anomsgtext",
                 "-AskipUses=SkipMe");
     }
 

--- a/checker/src/test/java/org/checkerframework/checker/test/junit/NullnessStubfileTest.java
+++ b/checker/src/test/java/org/checkerframework/checker/test/junit/NullnessStubfileTest.java
@@ -18,7 +18,6 @@ public class NullnessStubfileTest extends CheckerFrameworkPerDirectoryTest {
                 testFiles,
                 org.checkerframework.checker.nullness.NullnessChecker.class,
                 "nullness",
-                "-Anomsgtext",
                 "-AstubWarnIfNotFound",
                 "-Astubs="
                         + String.join(

--- a/checker/src/test/java/org/checkerframework/checker/test/junit/NullnessTempTest.java
+++ b/checker/src/test/java/org/checkerframework/checker/test/junit/NullnessTempTest.java
@@ -23,7 +23,6 @@ public class NullnessTempTest extends CheckerFrameworkPerDirectoryTest {
                 testFiles,
                 org.checkerframework.checker.nullness.NullnessChecker.class,
                 "nullness",
-                "-Anomsgtext",
                 "-Alint=soundArrayCreationNullness,"
                         + NullnessChecker.LINT_REDUNDANTNULLCOMPARISON);
     }

--- a/checker/src/test/java/org/checkerframework/checker/test/junit/NullnessTest.java
+++ b/checker/src/test/java/org/checkerframework/checker/test/junit/NullnessTest.java
@@ -24,7 +24,6 @@ public class NullnessTest extends CheckerFrameworkPerDirectoryTest {
                 org.checkerframework.checker.nullness.NullnessChecker.class,
                 "nullness",
                 "-AcheckPurityAnnotations",
-                "-Anomsgtext",
                 "-Xlint:deprecation",
                 "-Alint=soundArrayCreationNullness,"
                         + NullnessChecker.LINT_REDUNDANTNULLCOMPARISON);

--- a/checker/src/test/java/org/checkerframework/checker/test/junit/OptionalTest.java
+++ b/checker/src/test/java/org/checkerframework/checker/test/junit/OptionalTest.java
@@ -15,11 +15,7 @@ public class OptionalTest extends CheckerFrameworkPerDirectoryTest {
      * @param testFiles the files containing test code, which will be type-checked
      */
     public OptionalTest(List<File> testFiles) {
-        super(
-                testFiles,
-                org.checkerframework.checker.optional.OptionalChecker.class,
-                "optional",
-                "-Anomsgtext");
+        super(testFiles, org.checkerframework.checker.optional.OptionalChecker.class, "optional");
     }
 
     @Parameters

--- a/checker/src/test/java/org/checkerframework/checker/test/junit/RegexTest.java
+++ b/checker/src/test/java/org/checkerframework/checker/test/junit/RegexTest.java
@@ -14,11 +14,7 @@ public class RegexTest extends CheckerFrameworkPerDirectoryTest {
      * @param testFiles the files containing test code, which will be type-checked
      */
     public RegexTest(List<File> testFiles) {
-        super(
-                testFiles,
-                org.checkerframework.checker.regex.RegexChecker.class,
-                "regex",
-                "-Anomsgtext");
+        super(testFiles, org.checkerframework.checker.regex.RegexChecker.class, "regex");
     }
 
     @Parameters

--- a/checker/src/test/java/org/checkerframework/checker/test/junit/ResourceLeakNoCreatesMustCallForTest.java
+++ b/checker/src/test/java/org/checkerframework/checker/test/junit/ResourceLeakNoCreatesMustCallForTest.java
@@ -14,7 +14,6 @@ public class ResourceLeakNoCreatesMustCallForTest extends CheckerFrameworkPerDir
                 testFiles,
                 ResourceLeakChecker.class,
                 "resourceleak-nocreatesmustcallfor",
-                "-Anomsgtext",
                 "-AnoCreatesMustCallFor",
                 "-AwarnUnneededSuppressions",
                 "-encoding",

--- a/checker/src/test/java/org/checkerframework/checker/test/junit/ResourceLeakNoLightweightOwnershipTest.java
+++ b/checker/src/test/java/org/checkerframework/checker/test/junit/ResourceLeakNoLightweightOwnershipTest.java
@@ -14,7 +14,6 @@ public class ResourceLeakNoLightweightOwnershipTest extends CheckerFrameworkPerD
                 testFiles,
                 ResourceLeakChecker.class,
                 "resourceleak-nolightweightownership",
-                "-Anomsgtext",
                 "-AnoLightweightOwnership",
                 "-nowarn",
                 "-encoding",

--- a/checker/src/test/java/org/checkerframework/checker/test/junit/ResourceLeakNoResourceAliasesTest.java
+++ b/checker/src/test/java/org/checkerframework/checker/test/junit/ResourceLeakNoResourceAliasesTest.java
@@ -14,7 +14,6 @@ public class ResourceLeakNoResourceAliasesTest extends CheckerFrameworkPerDirect
                 testFiles,
                 ResourceLeakChecker.class,
                 "resourceleak-noresourcealiases",
-                "-Anomsgtext",
                 "-AnoResourceAliases",
                 "-nowarn",
                 "-encoding",

--- a/checker/src/test/java/org/checkerframework/checker/test/junit/ResourceLeakTest.java
+++ b/checker/src/test/java/org/checkerframework/checker/test/junit/ResourceLeakTest.java
@@ -14,7 +14,6 @@ public class ResourceLeakTest extends CheckerFrameworkPerDirectoryTest {
                 testFiles,
                 ResourceLeakChecker.class,
                 "resourceleak",
-                "-Anomsgtext",
                 "-AwarnUnneededSuppressions",
                 "-encoding",
                 "UTF-8");

--- a/checker/src/test/java/org/checkerframework/checker/test/junit/SignatureTest.java
+++ b/checker/src/test/java/org/checkerframework/checker/test/junit/SignatureTest.java
@@ -17,8 +17,7 @@ public class SignatureTest extends CheckerFrameworkPerDirectoryTest {
         super(
                 testFiles,
                 org.checkerframework.checker.signature.SignatureChecker.class,
-                "signature",
-                "-Anomsgtext");
+                "signature");
     }
 
     @Parameters

--- a/checker/src/test/java/org/checkerframework/checker/test/junit/SignednessTest.java
+++ b/checker/src/test/java/org/checkerframework/checker/test/junit/SignednessTest.java
@@ -17,8 +17,7 @@ public class SignednessTest extends CheckerFrameworkPerDirectoryTest {
         super(
                 testFiles,
                 org.checkerframework.checker.signedness.SignednessChecker.class,
-                "signedness",
-                "-Anomsgtext");
+                "signedness");
     }
 
     @Parameters

--- a/checker/src/test/java/org/checkerframework/checker/test/junit/SignednessUncheckedDefaultsTest.java
+++ b/checker/src/test/java/org/checkerframework/checker/test/junit/SignednessUncheckedDefaultsTest.java
@@ -18,7 +18,6 @@ public class SignednessUncheckedDefaultsTest extends CheckerFrameworkPerDirector
                 testFiles,
                 org.checkerframework.checker.signedness.SignednessChecker.class,
                 "signedness",
-                "-Anomsgtext",
                 "-AuseConservativeDefaultsForUncheckedCode=-source,bytecode");
     }
 

--- a/checker/src/test/java/org/checkerframework/checker/test/junit/StubparserNullnessTest.java
+++ b/checker/src/test/java/org/checkerframework/checker/test/junit/StubparserNullnessTest.java
@@ -19,7 +19,6 @@ public class StubparserNullnessTest extends CheckerFrameworkPerDirectoryTest {
                 testFiles,
                 org.checkerframework.checker.nullness.NullnessChecker.class,
                 "stubparser-nullness",
-                "-Anomsgtext",
                 "-Astubs=tests/stubparser-nullness",
                 "-AstubWarnIfNotFound");
     }

--- a/checker/src/test/java/org/checkerframework/checker/test/junit/StubparserRecordTest.java
+++ b/checker/src/test/java/org/checkerframework/checker/test/junit/StubparserRecordTest.java
@@ -19,7 +19,6 @@ public class StubparserRecordTest extends CheckerFrameworkPerDirectoryTest {
                 testFiles,
                 org.checkerframework.checker.nullness.NullnessChecker.class,
                 "stubparser-records",
-                "-Anomsgtext",
                 "-Astubs=tests/stubparser-records",
                 "-AstubWarnIfNotFound");
     }

--- a/checker/src/test/java/org/checkerframework/checker/test/junit/StubparserTaintingTest.java
+++ b/checker/src/test/java/org/checkerframework/checker/test/junit/StubparserTaintingTest.java
@@ -19,7 +19,6 @@ public class StubparserTaintingTest extends CheckerFrameworkPerDirectoryTest {
                 testFiles,
                 org.checkerframework.checker.tainting.TaintingChecker.class,
                 "stubparser-tainting",
-                "-Anomsgtext",
                 "-AmergeStubsWithSource",
                 "-Astubs=tests/stubparser-tainting",
                 "-AstubWarnIfNotFound");

--- a/checker/src/test/java/org/checkerframework/checker/test/junit/TaintingTest.java
+++ b/checker/src/test/java/org/checkerframework/checker/test/junit/TaintingTest.java
@@ -15,7 +15,7 @@ public class TaintingTest extends CheckerFrameworkPerDirectoryTest {
      * @param testFiles the files containing test code, which will be type-checked
      */
     public TaintingTest(List<File> testFiles) {
-        super(testFiles, TaintingChecker.class, "tainting", "-Anomsgtext");
+        super(testFiles, TaintingChecker.class, "tainting");
     }
 
     @Parameters

--- a/checker/src/test/java/org/checkerframework/checker/test/junit/UnitsTest.java
+++ b/checker/src/test/java/org/checkerframework/checker/test/junit/UnitsTest.java
@@ -14,11 +14,7 @@ public class UnitsTest extends CheckerFrameworkPerDirectoryTest {
      * @param testFiles the files containing test code, which will be type-checked
      */
     public UnitsTest(List<File> testFiles) {
-        super(
-                testFiles,
-                org.checkerframework.checker.units.UnitsChecker.class,
-                "units",
-                "-Anomsgtext");
+        super(testFiles, org.checkerframework.checker.units.UnitsChecker.class, "units");
     }
 
     @Parameters

--- a/checker/src/test/java/org/checkerframework/checker/test/junit/ValueIndexInteractionTest.java
+++ b/checker/src/test/java/org/checkerframework/checker/test/junit/ValueIndexInteractionTest.java
@@ -18,8 +18,7 @@ public class ValueIndexInteractionTest extends CheckerFrameworkPerDirectoryTest 
         super(
                 testFiles,
                 org.checkerframework.common.value.ValueChecker.class,
-                "value-index-interaction",
-                "-Anomsgtext");
+                "value-index-interaction");
     }
 
     @Parameters

--- a/checker/src/test/java/org/checkerframework/checker/test/junit/ainferrunners/AinferNullnessJaifsTest.java
+++ b/checker/src/test/java/org/checkerframework/checker/test/junit/ainferrunners/AinferNullnessJaifsTest.java
@@ -19,13 +19,7 @@ import java.util.List;
 public class AinferNullnessJaifsTest extends CheckerFrameworkPerDirectoryTest {
     /** @param testFiles the files containing test code, which will be type-checked */
     public AinferNullnessJaifsTest(List<File> testFiles) {
-        super(
-                testFiles,
-                NullnessChecker.class,
-                "nullness",
-                "-Anomsgtext",
-                "-Ainfer=jaifs",
-                "-Awarns");
+        super(testFiles, NullnessChecker.class, "nullness", "-Ainfer=jaifs", "-Awarns");
     }
 
     @Parameters

--- a/checker/src/test/java/org/checkerframework/checker/test/junit/ainferrunners/AinferNullnessJaifsValidationTest.java
+++ b/checker/src/test/java/org/checkerframework/checker/test/junit/ainferrunners/AinferNullnessJaifsValidationTest.java
@@ -16,7 +16,7 @@ import java.util.List;
 public class AinferNullnessJaifsValidationTest extends CheckerFrameworkPerDirectoryTest {
     /** @param testFiles the files containing test code, which will be type-checked */
     public AinferNullnessJaifsValidationTest(List<File> testFiles) {
-        super(testFiles, NullnessChecker.class, "nullness", "-Anomsgtext");
+        super(testFiles, NullnessChecker.class, "nullness");
     }
 
     @Override

--- a/checker/src/test/java/org/checkerframework/checker/test/junit/ainferrunners/AinferTestCheckerAjavaTest.java
+++ b/checker/src/test/java/org/checkerframework/checker/test/junit/ainferrunners/AinferTestCheckerAjavaTest.java
@@ -25,7 +25,6 @@ public class AinferTestCheckerAjavaTest extends CheckerFrameworkPerDirectoryTest
                 testFiles,
                 AinferTestChecker.class,
                 "ainfer-testchecker/non-annotated",
-                "-Anomsgtext",
                 "-Ainfer=ajava",
                 "-Awarns");
     }

--- a/checker/src/test/java/org/checkerframework/checker/test/junit/ainferrunners/AinferTestCheckerAjavaValidationTest.java
+++ b/checker/src/test/java/org/checkerframework/checker/test/junit/ainferrunners/AinferTestCheckerAjavaValidationTest.java
@@ -22,7 +22,6 @@ public class AinferTestCheckerAjavaValidationTest extends CheckerFrameworkPerDir
                 testFiles,
                 AinferTestChecker.class,
                 "ainfer-testchecker/annotated",
-                "-Anomsgtext",
                 "-Aajava=tests/ainfer-testchecker/inference-output",
                 "-Awarns");
     }

--- a/checker/src/test/java/org/checkerframework/checker/test/junit/ainferrunners/AinferTestCheckerJaifsTest.java
+++ b/checker/src/test/java/org/checkerframework/checker/test/junit/ainferrunners/AinferTestCheckerJaifsTest.java
@@ -23,7 +23,6 @@ public class AinferTestCheckerJaifsTest extends CheckerFrameworkPerDirectoryTest
                 testFiles,
                 AinferTestChecker.class,
                 "ainfer-testchecker/non-annotated",
-                "-Anomsgtext",
                 "-Ainfer=jaifs",
                 "-Awarns");
     }

--- a/checker/src/test/java/org/checkerframework/checker/test/junit/ainferrunners/AinferTestCheckerJaifsValidationTest.java
+++ b/checker/src/test/java/org/checkerframework/checker/test/junit/ainferrunners/AinferTestCheckerJaifsValidationTest.java
@@ -16,12 +16,7 @@ import java.util.List;
 public class AinferTestCheckerJaifsValidationTest extends CheckerFrameworkPerDirectoryTest {
     /** @param testFiles the files containing test code, which will be type-checked */
     public AinferTestCheckerJaifsValidationTest(List<File> testFiles) {
-        super(
-                testFiles,
-                AinferTestChecker.class,
-                "ainfer-testchecker/non-annotated",
-                "-Anomsgtext",
-                "-Awarns");
+        super(testFiles, AinferTestChecker.class, "ainfer-testchecker/non-annotated", "-Awarns");
     }
 
     @Override

--- a/checker/src/test/java/org/checkerframework/checker/test/junit/ainferrunners/AinferTestCheckerStubsTest.java
+++ b/checker/src/test/java/org/checkerframework/checker/test/junit/ainferrunners/AinferTestCheckerStubsTest.java
@@ -25,7 +25,6 @@ public class AinferTestCheckerStubsTest extends CheckerFrameworkPerDirectoryTest
                 testFiles,
                 AinferTestChecker.class,
                 "ainfer-testchecker/non-annotated",
-                "-Anomsgtext",
                 "-Ainfer=stubs",
                 "-Awarns");
     }

--- a/checker/src/test/java/org/checkerframework/checker/test/junit/ainferrunners/AinferTestCheckerStubsValidationTest.java
+++ b/checker/src/test/java/org/checkerframework/checker/test/junit/ainferrunners/AinferTestCheckerStubsValidationTest.java
@@ -21,7 +21,6 @@ public class AinferTestCheckerStubsValidationTest extends CheckerFrameworkPerDir
                 testFiles,
                 AinferTestChecker.class,
                 "ainfer-testchecker/annotated",
-                "-Anomsgtext",
                 "-Astubs=tests/ainfer-testchecker/inference-output",
                 // "-AstubDebug",
                 "-AmergeStubsWithSource",

--- a/framework-test/src/main/java/org/checkerframework/framework/test/CheckerFrameworkPerDirectoryTest.java
+++ b/framework-test/src/main/java/org/checkerframework/framework/test/CheckerFrameworkPerDirectoryTest.java
@@ -137,9 +137,6 @@ public abstract class CheckerFrameworkPerDirectoryTest {
         this.testDir = "tests" + File.separator + testDir;
         this.classpathExtra = classpathExtra;
         this.checkerOptions = new ArrayList<>(Arrays.asList(checkerOptions));
-        // -Anomsgtext is needed to ensure expected errors can be matched
-        this.checkerOptions.add("-Anomsgtext");
-        this.checkerOptions.add("-AajavaChecks");
     }
 
     @Test

--- a/framework-test/src/main/java/org/checkerframework/framework/test/CheckerFrameworkPerDirectoryTest.java
+++ b/framework-test/src/main/java/org/checkerframework/framework/test/CheckerFrameworkPerDirectoryTest.java
@@ -137,6 +137,8 @@ public abstract class CheckerFrameworkPerDirectoryTest {
         this.testDir = "tests" + File.separator + testDir;
         this.classpathExtra = classpathExtra;
         this.checkerOptions = new ArrayList<>(Arrays.asList(checkerOptions));
+        // -Anomsgtext is needed to ensure expected errors can be matched
+        this.checkerOptions.add("-Anomsgtext");
         this.checkerOptions.add("-AajavaChecks");
     }
 

--- a/framework-test/src/main/java/org/checkerframework/framework/test/TypecheckExecutor.java
+++ b/framework-test/src/main/java/org/checkerframework/framework/test/TypecheckExecutor.java
@@ -97,6 +97,10 @@ public class TypecheckExecutor {
 
         nonJvmOptions.add("-AnoJreVersionCheck");
 
+        // -Anomsgtext is needed to ensure expected errors can be matched
+        nonJvmOptions.add("-Anomsgtext");
+        nonJvmOptions.add("-AajavaChecks");
+
         options.addAll(nonJvmOptions);
 
         if (configuration.shouldEmitDebugInfo()) {

--- a/framework-test/src/main/java/org/checkerframework/framework/test/TypecheckResult.java
+++ b/framework-test/src/main/java/org/checkerframework/framework/test/TypecheckResult.java
@@ -145,10 +145,8 @@ public class TypecheckResult {
             CompilationResult result,
             List<TestDiagnostic> expectedDiagnostics) {
 
-        boolean usingAnomsgtxt = configuration.getOptions().containsKey("-Anomsgtext");
         final Set<TestDiagnostic> actualDiagnostics =
-                TestDiagnosticUtils.fromJavaxDiagnosticList(
-                        result.getDiagnostics(), usingAnomsgtxt);
+                TestDiagnosticUtils.fromJavaxDiagnosticList(result.getDiagnostics(), true);
 
         final Set<TestDiagnostic> unexpectedDiagnostics = new LinkedHashSet<>();
         unexpectedDiagnostics.addAll(actualDiagnostics);

--- a/framework/src/main/java/org/checkerframework/framework/flow/CFAbstractTransfer.java
+++ b/framework/src/main/java/org/checkerframework/framework/flow/CFAbstractTransfer.java
@@ -1355,7 +1355,14 @@ public abstract class CFAbstractTransfer<
     public TransferResult<V, S> visitStringConversion(
             StringConversionNode n, TransferInput<V, S> p) {
         TransferResult<V, S> result = super.visitStringConversion(n, p);
-        result.setResultValue(p.getValueOfSubNode(n.getOperand()));
+        TypeMirror strType = n.getType();
+        V operandValue = p.getValueOfSubNode(n.getOperand());
+        V convertedStringValue =
+                analysis.createAbstractValue(
+                        analysis.atypeFactory.getAnnoOrTypeBound(
+                                strType, operandValue.getAnnotations()),
+                        strType);
+        result.setResultValue(convertedStringValue);
         return result;
     }
 

--- a/framework/src/main/java/org/checkerframework/framework/flow/CFAbstractTransfer.java
+++ b/framework/src/main/java/org/checkerframework/framework/flow/CFAbstractTransfer.java
@@ -1356,13 +1356,12 @@ public abstract class CFAbstractTransfer<
             StringConversionNode n, TransferInput<V, S> p) {
         TransferResult<V, S> result = super.visitStringConversion(n, p);
         TypeMirror strType = n.getType();
-        V operandValue = p.getValueOfSubNode(n.getOperand());
-        V convertedStringValue =
-                analysis.createAbstractValue(
-                        analysis.atypeFactory.getAnnoOrTypeBound(
-                                strType, operandValue.getAnnotations()),
-                        strType);
-        result.setResultValue(convertedStringValue);
+        Tree operandTree = n.getOperand().getTree();
+        Set<AnnotationMirror> operandAnnos =
+                analysis.atypeFactory.getAnnotatedType(operandTree).getEffectiveAnnotations();
+        Set<AnnotationMirror> resultAnnos =
+                analysis.atypeFactory.getAnnoOrTypeBound(strType, operandAnnos);
+        result.setResultValue(analysis.createAbstractValue(resultAnnos, strType));
         return result;
     }
 

--- a/framework/src/main/java/org/checkerframework/framework/type/AnnotatedTypeFactory.java
+++ b/framework/src/main/java/org/checkerframework/framework/type/AnnotatedTypeFactory.java
@@ -5733,10 +5733,11 @@ public class AnnotatedTypeFactory implements AnnotationProvider {
     /**
      * Returns the qualifiers in {@code annos} that are below the qualifier upper bound of {@code
      * type}. If a qualifier in {@code annos} is above the bound, then the bound is added to the
-     * result instead.g
+     * result instead.
      *
      * @param type java type that specifies the qualifier upper bound
      * @param annos annotations to add to the {@link AnnotatedTypeMirror} of type
+     * @return the modified {@code annos} by applying the rules above
      */
     public Set<AnnotationMirror> getAnnoOrTypeBound(
             TypeMirror type, Set<? extends AnnotationMirror> annos) {

--- a/framework/src/main/java/org/checkerframework/framework/type/AnnotatedTypeFactory.java
+++ b/framework/src/main/java/org/checkerframework/framework/type/AnnotatedTypeFactory.java
@@ -5729,4 +5729,31 @@ public class AnnotatedTypeFactory implements AnnotationProvider {
         }
         return ImmutableTypes.isImmutable(TypeAnnotationUtils.unannotatedType(type).toString());
     }
+
+    /**
+     * Returns the qualifiers in {@code annos} that are below the qualifier upper bound of {@code
+     * type}. If a qualifier in {@code annos} is above the bound, then the bound is added to the
+     * result instead.g
+     *
+     * @param type java type that specifies the qualifier upper bound
+     * @param annos annotations to add to the {@link AnnotatedTypeMirror} of type
+     */
+    public Set<AnnotationMirror> getAnnoOrTypeBound(
+            TypeMirror type, Set<? extends AnnotationMirror> annos) {
+        Set<AnnotationMirror> boundAnnos = getTypeDeclarationBounds(type);
+        Set<AnnotationMirror> results = AnnotationUtils.createAnnotationSet();
+
+        for (AnnotationMirror anno : annos) {
+            AnnotationMirror boundAnno =
+                    qualHierarchy.findAnnotationInSameHierarchy(boundAnnos, anno);
+            assert boundAnno != null;
+
+            if (!qualHierarchy.isSubtype(anno, boundAnno)) {
+                results.add(boundAnno);
+            } else {
+                results.add(anno);
+            }
+        }
+        return results;
+    }
 }

--- a/framework/src/main/java/org/checkerframework/framework/type/treeannotator/PropagationTreeAnnotator.java
+++ b/framework/src/main/java/org/checkerframework/framework/type/treeannotator/PropagationTreeAnnotator.java
@@ -18,7 +18,6 @@ import org.checkerframework.framework.type.AnnotatedTypeMirror;
 import org.checkerframework.framework.type.AnnotatedTypeMirror.AnnotatedArrayType;
 import org.checkerframework.framework.type.AnnotatedTypeMirror.AnnotatedExecutableType;
 import org.checkerframework.framework.type.QualifierHierarchy;
-import org.checkerframework.javacutil.AnnotationUtils;
 import org.checkerframework.javacutil.CollectionUtils;
 import org.checkerframework.javacutil.Pair;
 import org.checkerframework.javacutil.TreePathUtil;
@@ -337,16 +336,8 @@ public class PropagationTreeAnnotator extends TreeAnnotator {
      * @param annos annotations to add to type
      */
     private void addAnnoOrBound(AnnotatedTypeMirror type, Set<? extends AnnotationMirror> annos) {
-        Set<AnnotationMirror> boundAnnos =
-                atypeFactory.getQualifierUpperBounds().getBoundQualifiers(type.getUnderlyingType());
-        Set<AnnotationMirror> annosToAdd = AnnotationUtils.createAnnotationSet();
-        for (AnnotationMirror boundAnno : boundAnnos) {
-            AnnotationMirror anno = qualHierarchy.findAnnotationInSameHierarchy(annos, boundAnno);
-            if (anno != null && !qualHierarchy.isSubtype(anno, boundAnno)) {
-                annosToAdd.add(boundAnno);
-            }
-        }
+        Set<AnnotationMirror> annosToAdd =
+                atypeFactory.getAnnoOrTypeBound(type.getUnderlyingType(), annos);
         type.addMissingAnnotations(annosToAdd);
-        type.addMissingAnnotations(annos);
     }
 }

--- a/framework/src/test/java/org/checkerframework/framework/test/junit/AccumulationNoReturnsReceiverTest.java
+++ b/framework/src/test/java/org/checkerframework/framework/test/junit/AccumulationNoReturnsReceiverTest.java
@@ -19,7 +19,6 @@ public class AccumulationNoReturnsReceiverTest extends CheckerFrameworkPerDirect
                 testFiles,
                 TestAccumulationNoReturnsReceiverChecker.class,
                 "accumulation-norr",
-                "-Anomsgtext",
                 "-encoding",
                 "UTF-8");
     }

--- a/framework/src/test/java/org/checkerframework/framework/test/junit/AccumulationTest.java
+++ b/framework/src/test/java/org/checkerframework/framework/test/junit/AccumulationTest.java
@@ -15,13 +15,7 @@ public class AccumulationTest extends CheckerFrameworkPerDirectoryTest {
 
     /** @param testFiles the files containing test code, which will be type-checked */
     public AccumulationTest(List<File> testFiles) {
-        super(
-                testFiles,
-                TestAccumulationChecker.class,
-                "accumulation",
-                "-Anomsgtext",
-                "-encoding",
-                "UTF-8");
+        super(testFiles, TestAccumulationChecker.class, "accumulation", "-encoding", "UTF-8");
     }
 
     @Parameters

--- a/framework/src/test/java/org/checkerframework/framework/test/junit/AggregateTest.java
+++ b/framework/src/test/java/org/checkerframework/framework/test/junit/AggregateTest.java
@@ -11,12 +11,7 @@ public class AggregateTest extends CheckerFrameworkPerDirectoryTest {
 
     /** @param testFiles the files containing test code, which will be type-checked */
     public AggregateTest(List<File> testFiles) {
-        super(
-                testFiles,
-                AggregateOfCompoundChecker.class,
-                "aggregate",
-                "-Anomsgtext",
-                "-AresolveReflection");
+        super(testFiles, AggregateOfCompoundChecker.class, "aggregate", "-AresolveReflection");
     }
 
     @Parameters

--- a/framework/src/test/java/org/checkerframework/framework/test/junit/AliasingTest.java
+++ b/framework/src/test/java/org/checkerframework/framework/test/junit/AliasingTest.java
@@ -10,11 +10,7 @@ public class AliasingTest extends CheckerFrameworkPerDirectoryTest {
 
     /** @param testFiles the files containing test code, which will be type-checked */
     public AliasingTest(List<File> testFiles) {
-        super(
-                testFiles,
-                org.checkerframework.common.aliasing.AliasingChecker.class,
-                "aliasing",
-                "-Anomsgtext");
+        super(testFiles, org.checkerframework.common.aliasing.AliasingChecker.class, "aliasing");
     }
 
     @Parameters

--- a/framework/src/test/java/org/checkerframework/framework/test/junit/AnnotatedForTest.java
+++ b/framework/src/test/java/org/checkerframework/framework/test/junit/AnnotatedForTest.java
@@ -15,7 +15,6 @@ public class AnnotatedForTest extends CheckerFrameworkPerDirectoryTest {
                 testFiles,
                 org.checkerframework.common.subtyping.SubtypingChecker.class,
                 "subtyping",
-                "-Anomsgtext",
                 "-Aquals=org.checkerframework.framework.testchecker.util.SubQual,org.checkerframework.framework.testchecker.util.SuperQual",
                 "-AuseConservativeDefaultsForUncheckedCode=source,bytecode");
     }

--- a/framework/src/test/java/org/checkerframework/framework/test/junit/ClassValTest.java
+++ b/framework/src/test/java/org/checkerframework/framework/test/junit/ClassValTest.java
@@ -11,11 +11,7 @@ public class ClassValTest extends CheckerFrameworkPerDirectoryTest {
 
     /** @param testFiles the files containing test code, which will be type-checked */
     public ClassValTest(List<File> testFiles) {
-        super(
-                testFiles,
-                org.checkerframework.common.reflection.ClassValChecker.class,
-                "classval",
-                "-Anomsgtext");
+        super(testFiles, org.checkerframework.common.reflection.ClassValChecker.class, "classval");
     }
 
     @Parameters

--- a/framework/src/test/java/org/checkerframework/framework/test/junit/CompoundCheckerTest.java
+++ b/framework/src/test/java/org/checkerframework/framework/test/junit/CompoundCheckerTest.java
@@ -16,7 +16,6 @@ public class CompoundCheckerTest extends CheckerFrameworkPerDirectoryTest {
                 testFiles,
                 CompoundChecker.class,
                 "compound-checker",
-                "-Anomsgtext",
                 "-AsuppressWarnings=type.checking.not.run");
     }
 

--- a/framework/src/test/java/org/checkerframework/framework/test/junit/DefaultingLowerBoundTest.java
+++ b/framework/src/test/java/org/checkerframework/framework/test/junit/DefaultingLowerBoundTest.java
@@ -12,7 +12,7 @@ public class DefaultingLowerBoundTest extends CheckerFrameworkPerDirectoryTest {
 
     /** @param testFiles the files containing test code, which will be type-checked */
     public DefaultingLowerBoundTest(List<File> testFiles) {
-        super(testFiles, DefaultingLowerBoundChecker.class, "defaulting", "-Anomsgtext");
+        super(testFiles, DefaultingLowerBoundChecker.class, "defaulting");
     }
 
     @Parameters

--- a/framework/src/test/java/org/checkerframework/framework/test/junit/DefaultingUpperBoundTest.java
+++ b/framework/src/test/java/org/checkerframework/framework/test/junit/DefaultingUpperBoundTest.java
@@ -12,7 +12,7 @@ public class DefaultingUpperBoundTest extends CheckerFrameworkPerDirectoryTest {
 
     /** @param testFiles the files containing test code, which will be type-checked */
     public DefaultingUpperBoundTest(List<File> testFiles) {
-        super(testFiles, DefaultingUpperBoundChecker.class, "defaulting", "-Anomsgtext");
+        super(testFiles, DefaultingUpperBoundChecker.class, "defaulting");
     }
 
     @Parameters

--- a/framework/src/test/java/org/checkerframework/framework/test/junit/Flow2Test.java
+++ b/framework/src/test/java/org/checkerframework/framework/test/junit/Flow2Test.java
@@ -16,7 +16,7 @@ public class Flow2Test extends CheckerFrameworkPerDirectoryTest {
 
     /** @param testFiles the files containing test code, which will be type-checked */
     public Flow2Test(List<File> testFiles) {
-        super(testFiles, FlowTestChecker.class, "flow", "-Anomsgtext", "-AcheckPurityAnnotations");
+        super(testFiles, FlowTestChecker.class, "flow", "-AcheckPurityAnnotations");
     }
 
     @Parameters

--- a/framework/src/test/java/org/checkerframework/framework/test/junit/FlowExpressionCheckerTest.java
+++ b/framework/src/test/java/org/checkerframework/framework/test/junit/FlowExpressionCheckerTest.java
@@ -11,7 +11,7 @@ public class FlowExpressionCheckerTest extends CheckerFrameworkPerDirectoryTest 
 
     /** @param testFiles the files containing test code, which will be type-checked */
     public FlowExpressionCheckerTest(List<File> testFiles) {
-        super(testFiles, FlowExpressionChecker.class, "flowexpression", "-Anomsgtext");
+        super(testFiles, FlowExpressionChecker.class, "flowexpression");
     }
 
     @Parameters

--- a/framework/src/test/java/org/checkerframework/framework/test/junit/FlowTest.java
+++ b/framework/src/test/java/org/checkerframework/framework/test/junit/FlowTest.java
@@ -12,7 +12,7 @@ public class FlowTest extends CheckerFrameworkPerDirectoryTest {
 
     /** @param testFiles the files containing test code, which will be type-checked */
     public FlowTest(List<File> testFiles) {
-        super(testFiles, FlowTestChecker.class, "flow", "-Anomsgtext");
+        super(testFiles, FlowTestChecker.class, "flow");
     }
 
     @Parameters

--- a/framework/src/test/java/org/checkerframework/framework/test/junit/H1H2CheckerTest.java
+++ b/framework/src/test/java/org/checkerframework/framework/test/junit/H1H2CheckerTest.java
@@ -16,7 +16,6 @@ public class H1H2CheckerTest extends CheckerFrameworkPerDirectoryTest {
                 testFiles,
                 H1H2Checker.class,
                 "h1h2checker",
-                "-Anomsgtext",
                 "-Astubs=tests/h1h2checker/h1h2checker.astub");
     }
 

--- a/framework/src/test/java/org/checkerframework/framework/test/junit/ImplicitConversionTest.java
+++ b/framework/src/test/java/org/checkerframework/framework/test/junit/ImplicitConversionTest.java
@@ -1,0 +1,20 @@
+package org.checkerframework.framework.test.junit;
+
+import org.checkerframework.framework.test.CheckerFrameworkPerDirectoryTest;
+import org.checkerframework.framework.testchecker.implicitconversion.ImplicitConversionTestChecker;
+import org.junit.runners.Parameterized;
+
+import java.io.File;
+import java.util.List;
+
+public class ImplicitConversionTest extends CheckerFrameworkPerDirectoryTest {
+
+    public ImplicitConversionTest(List<File> testFiles) {
+        super(testFiles, ImplicitConversionTestChecker.class, "implicitconversion");
+    }
+
+    @Parameterized.Parameters
+    public static String[] getTestDirs() {
+        return new String[] {"implicitconversion"};
+    }
+}

--- a/framework/src/test/java/org/checkerframework/framework/test/junit/InitializedFieldsTest.java
+++ b/framework/src/test/java/org/checkerframework/framework/test/junit/InitializedFieldsTest.java
@@ -15,7 +15,7 @@ public class InitializedFieldsTest extends CheckerFrameworkPerDirectoryTest {
      * @param testFiles the files containing test code, which will be type-checked
      */
     public InitializedFieldsTest(List<File> testFiles) {
-        super(testFiles, InitializedFieldsChecker.class, "initialized-fields", "-Anomsgtext");
+        super(testFiles, InitializedFieldsChecker.class, "initialized-fields");
     }
 
     @Parameters

--- a/framework/src/test/java/org/checkerframework/framework/test/junit/InitializedFieldsValueTest.java
+++ b/framework/src/test/java/org/checkerframework/framework/test/junit/InitializedFieldsValueTest.java
@@ -23,7 +23,6 @@ public class InitializedFieldsValueTest extends CheckerFrameworkPerDirectoryTest
                         "org.checkerframework.common.value.ValueChecker"),
                 "initialized-fields-value",
                 Collections.emptyList(), // classpathextra
-                "-Anomsgtext",
                 "-AsuppressWarnings=type.checking.not.run");
     }
 

--- a/framework/src/test/java/org/checkerframework/framework/test/junit/LubGlbTest.java
+++ b/framework/src/test/java/org/checkerframework/framework/test/junit/LubGlbTest.java
@@ -12,7 +12,7 @@ public class LubGlbTest extends CheckerFrameworkPerDirectoryTest {
 
     /** @param testFiles the files containing test code, which will be type-checked */
     public LubGlbTest(List<File> testFiles) {
-        super(testFiles, LubGlbChecker.class, "lubglb", "-Anomsgtext");
+        super(testFiles, LubGlbChecker.class, "lubglb");
     }
 
     @Parameters

--- a/framework/src/test/java/org/checkerframework/framework/test/junit/MethodValTest.java
+++ b/framework/src/test/java/org/checkerframework/framework/test/junit/MethodValTest.java
@@ -14,8 +14,7 @@ public class MethodValTest extends CheckerFrameworkPerDirectoryTest {
         super(
                 testFiles,
                 org.checkerframework.common.reflection.MethodValChecker.class,
-                "methodval",
-                "-Anomsgtext");
+                "methodval");
     }
 
     @Parameters

--- a/framework/src/test/java/org/checkerframework/framework/test/junit/NonTopDefaultTest.java
+++ b/framework/src/test/java/org/checkerframework/framework/test/junit/NonTopDefaultTest.java
@@ -12,7 +12,7 @@ public class NonTopDefaultTest extends CheckerFrameworkPerDirectoryTest {
 
     /** @param testFiles the files containing test code, which will be type-checked */
     public NonTopDefaultTest(List<File> testFiles) {
-        super(testFiles, NTDChecker.class, "nontopdefault", "-Anomsgtext");
+        super(testFiles, NTDChecker.class, "nontopdefault");
     }
 
     @Parameters

--- a/framework/src/test/java/org/checkerframework/framework/test/junit/PuritySuggestionsTest.java
+++ b/framework/src/test/java/org/checkerframework/framework/test/junit/PuritySuggestionsTest.java
@@ -16,7 +16,6 @@ public class PuritySuggestionsTest extends CheckerFrameworkPerDirectoryTest {
                 testFiles,
                 FlowTestChecker.class,
                 "flow",
-                "-Anomsgtext",
                 "-AsuggestPureMethods",
                 "-AcheckPurityAnnotations");
     }

--- a/framework/src/test/java/org/checkerframework/framework/test/junit/ReflectionTest.java
+++ b/framework/src/test/java/org/checkerframework/framework/test/junit/ReflectionTest.java
@@ -13,7 +13,7 @@ public class ReflectionTest extends CheckerFrameworkPerDirectoryTest {
 
     /** @param testFiles the files containing test code, which will be type-checked */
     public ReflectionTest(List<File> testFiles) {
-        super(testFiles, ReflectionTestChecker.class, "reflection", "-Anomsgtext");
+        super(testFiles, ReflectionTestChecker.class, "reflection");
     }
 
     @Parameters

--- a/framework/src/test/java/org/checkerframework/framework/test/junit/ReportModifiersTest.java
+++ b/framework/src/test/java/org/checkerframework/framework/test/junit/ReportModifiersTest.java
@@ -14,7 +14,6 @@ public class ReportModifiersTest extends CheckerFrameworkPerDirectoryTest {
                 testFiles,
                 org.checkerframework.common.util.report.ReportChecker.class,
                 "report",
-                "-Anomsgtext",
                 "-AreportModifiers=native");
     }
 

--- a/framework/src/test/java/org/checkerframework/framework/test/junit/ReportTest.java
+++ b/framework/src/test/java/org/checkerframework/framework/test/junit/ReportTest.java
@@ -14,7 +14,6 @@ public class ReportTest extends CheckerFrameworkPerDirectoryTest {
                 testFiles,
                 org.checkerframework.common.util.report.ReportChecker.class,
                 "report",
-                "-Anomsgtext",
                 "-Astubs=tests/report/reporttest.astub");
     }
 

--- a/framework/src/test/java/org/checkerframework/framework/test/junit/ReportTreeKindsTest.java
+++ b/framework/src/test/java/org/checkerframework/framework/test/junit/ReportTreeKindsTest.java
@@ -14,7 +14,6 @@ public class ReportTreeKindsTest extends CheckerFrameworkPerDirectoryTest {
                 testFiles,
                 org.checkerframework.common.util.report.ReportChecker.class,
                 "report",
-                "-Anomsgtext",
                 "-AreportTreeKinds=WHILE_LOOP,CONDITIONAL_AND");
     }
 

--- a/framework/src/test/java/org/checkerframework/framework/test/junit/ReturnsReceiverAutoValueTest.java
+++ b/framework/src/test/java/org/checkerframework/framework/test/junit/ReturnsReceiverAutoValueTest.java
@@ -25,7 +25,6 @@ public class ReturnsReceiverAutoValueTest extends CheckerFrameworkPerDirectoryTe
                         ReturnsReceiverChecker.class.getName()),
                 "basic",
                 Collections.emptyList(),
-                "-Anomsgtext",
                 "-nowarn");
     }
 

--- a/framework/src/test/java/org/checkerframework/framework/test/junit/ReturnsReceiverLombokTest.java
+++ b/framework/src/test/java/org/checkerframework/framework/test/junit/ReturnsReceiverLombokTest.java
@@ -18,7 +18,6 @@ public class ReturnsReceiverLombokTest extends CheckerFrameworkPerDirectoryTest 
                 testFiles,
                 ReturnsReceiverChecker.class,
                 "returnsreceiverdelomboked",
-                "-Anomsgtext",
                 "-nowarn",
                 "-AsuppressWarnings=type.anno.before.modifier");
     }

--- a/framework/src/test/java/org/checkerframework/framework/test/junit/ReturnsReceiverTest.java
+++ b/framework/src/test/java/org/checkerframework/framework/test/junit/ReturnsReceiverTest.java
@@ -19,7 +19,6 @@ public class ReturnsReceiverTest extends CheckerFrameworkPerDirectoryTest {
                 testFiles,
                 ReturnsReceiverChecker.class,
                 "returnsreceiver",
-                "-Anomsgtext",
                 "-Astubs=stubs/",
                 "-nowarn");
     }

--- a/framework/src/test/java/org/checkerframework/framework/test/junit/SubtypingEncryptedTest.java
+++ b/framework/src/test/java/org/checkerframework/framework/test/junit/SubtypingEncryptedTest.java
@@ -15,7 +15,6 @@ public class SubtypingEncryptedTest extends CheckerFrameworkPerDirectoryTest {
                 testFiles,
                 org.checkerframework.common.subtyping.SubtypingChecker.class,
                 "subtyping",
-                "-Anomsgtext",
                 "-Aquals=org.checkerframework.framework.testchecker.util.Encrypted,org.checkerframework.framework.testchecker.util.PolyEncrypted,org.checkerframework.common.subtyping.qual.Unqualified");
     }
 

--- a/framework/src/test/java/org/checkerframework/framework/test/junit/SubtypingStringPatternsFullTest.java
+++ b/framework/src/test/java/org/checkerframework/framework/test/junit/SubtypingStringPatternsFullTest.java
@@ -15,7 +15,6 @@ public class SubtypingStringPatternsFullTest extends CheckerFrameworkPerDirector
                 testFiles,
                 org.checkerframework.common.subtyping.SubtypingChecker.class,
                 "stringpatterns/stringpatterns-full",
-                "-Anomsgtext",
                 "-Aquals=org.checkerframework.framework.testchecker.util.PatternUnknown,org.checkerframework.framework.testchecker.util.PatternAB,org.checkerframework.framework.testchecker.util.PatternBC,org.checkerframework.framework.testchecker.util.PatternAC,org.checkerframework.framework.testchecker.util.PatternA,org.checkerframework.framework.testchecker.util.PatternB,org.checkerframework.framework.testchecker.util.PatternC,org.checkerframework.framework.testchecker.util.PatternBottomFull");
     }
 

--- a/framework/src/test/java/org/checkerframework/framework/test/junit/SupportedQualsTest.java
+++ b/framework/src/test/java/org/checkerframework/framework/test/junit/SupportedQualsTest.java
@@ -11,7 +11,7 @@ public class SupportedQualsTest extends CheckerFrameworkPerDirectoryTest {
 
     /** @param testFiles the files containing test code, which will be type-checked */
     public SupportedQualsTest(List<File> testFiles) {
-        super(testFiles, SupportedQualsChecker.class, "simple", "-Anomsgtext");
+        super(testFiles, SupportedQualsChecker.class, "simple");
     }
 
     @Parameters

--- a/framework/src/test/java/org/checkerframework/framework/test/junit/TypeDeclDefaultTest.java
+++ b/framework/src/test/java/org/checkerframework/framework/test/junit/TypeDeclDefaultTest.java
@@ -16,7 +16,6 @@ public class TypeDeclDefaultTest extends CheckerFrameworkPerDirectoryTest {
                 testFiles,
                 TypeDeclDefaultChecker.class,
                 "typedecldefault",
-                "-Anomsgtext",
                 "-Astubs=tests/typedecldefault/jdk.astub");
     }
 

--- a/framework/src/test/java/org/checkerframework/framework/test/junit/ValueIgnoreRangeOverflowTest.java
+++ b/framework/src/test/java/org/checkerframework/framework/test/junit/ValueIgnoreRangeOverflowTest.java
@@ -16,7 +16,6 @@ public class ValueIgnoreRangeOverflowTest extends CheckerFrameworkPerDirectoryTe
                 testFiles,
                 org.checkerframework.common.value.ValueChecker.class,
                 "value",
-                "-Anomsgtext",
                 "-A" + ValueChecker.REPORT_EVAL_WARNS,
                 "-A" + ValueChecker.IGNORE_RANGE_OVERFLOW);
     }

--- a/framework/src/test/java/org/checkerframework/framework/test/junit/ValueNonNullStringsConcatenationTest.java
+++ b/framework/src/test/java/org/checkerframework/framework/test/junit/ValueNonNullStringsConcatenationTest.java
@@ -15,7 +15,6 @@ public class ValueNonNullStringsConcatenationTest extends CheckerFrameworkPerDir
                 testFiles,
                 org.checkerframework.common.value.ValueChecker.class,
                 "value-non-null-strings-concatenation",
-                "-Anomsgtext",
                 "-A" + ValueChecker.REPORT_EVAL_WARNS,
                 "-A" + ValueChecker.NON_NULL_STRINGS_CONCATENATION);
     }

--- a/framework/src/test/java/org/checkerframework/framework/test/junit/ValueTest.java
+++ b/framework/src/test/java/org/checkerframework/framework/test/junit/ValueTest.java
@@ -22,7 +22,6 @@ public class ValueTest extends CheckerFrameworkPerDirectoryTest {
                 testFiles,
                 org.checkerframework.common.value.ValueChecker.class,
                 "value",
-                "-Anomsgtext",
                 "-Astubs=tests/value/minints-stub.astub:tests/value/lowercase.astub",
                 "-A" + ValueChecker.REPORT_EVAL_WARNS);
     }

--- a/framework/src/test/java/org/checkerframework/framework/test/junit/ValueUncheckedDefaultsTest.java
+++ b/framework/src/test/java/org/checkerframework/framework/test/junit/ValueUncheckedDefaultsTest.java
@@ -16,7 +16,6 @@ public class ValueUncheckedDefaultsTest extends CheckerFrameworkPerDirectoryTest
                 testFiles,
                 ValueChecker.class,
                 "value",
-                "-Anomsgtext",
                 "-AuseConservativeDefaultsForUncheckedCode=btyecode",
                 "-A" + ValueChecker.REPORT_EVAL_WARNS);
     }

--- a/framework/src/test/java/org/checkerframework/framework/test/junit/VariableNameDefaultTest.java
+++ b/framework/src/test/java/org/checkerframework/framework/test/junit/VariableNameDefaultTest.java
@@ -12,7 +12,7 @@ public class VariableNameDefaultTest extends CheckerFrameworkPerDirectoryTest {
 
     /** @param testFiles the files containing test code, which will be type-checked */
     public VariableNameDefaultTest(List<File> testFiles) {
-        super(testFiles, VariableNameDefaultChecker.class, "variablenamedefault", "-Anomsgtext");
+        super(testFiles, VariableNameDefaultChecker.class, "variablenamedefault");
     }
 
     @Parameters

--- a/framework/src/test/java/org/checkerframework/framework/test/junit/ViewpointTestCheckerTest.java
+++ b/framework/src/test/java/org/checkerframework/framework/test/junit/ViewpointTestCheckerTest.java
@@ -10,7 +10,7 @@ public class ViewpointTestCheckerTest extends CheckerFrameworkPerDirectoryTest {
 
     /** @param testFiles the files containing test code, which will be type-checked */
     public ViewpointTestCheckerTest(List<File> testFiles) {
-        super(testFiles, viewpointtest.ViewpointTestChecker.class, "viewpointtest", "-Anomsgtext");
+        super(testFiles, viewpointtest.ViewpointTestChecker.class, "viewpointtest");
     }
 
     @Parameterized.Parameters

--- a/framework/src/test/java/org/checkerframework/framework/testchecker/implicitconversion/ImplicitConversionTestAnnotatedTypeFactory.java
+++ b/framework/src/test/java/org/checkerframework/framework/testchecker/implicitconversion/ImplicitConversionTestAnnotatedTypeFactory.java
@@ -1,0 +1,24 @@
+package org.checkerframework.framework.testchecker.implicitconversion;
+
+import org.checkerframework.common.basetype.BaseAnnotatedTypeFactory;
+import org.checkerframework.common.basetype.BaseTypeChecker;
+import org.checkerframework.framework.testchecker.implicitconversion.quals.Bottom;
+import org.checkerframework.framework.testchecker.implicitconversion.quals.Top;
+
+import java.lang.annotation.Annotation;
+import java.util.Arrays;
+import java.util.HashSet;
+import java.util.Set;
+
+public class ImplicitConversionTestAnnotatedTypeFactory extends BaseAnnotatedTypeFactory {
+
+    public ImplicitConversionTestAnnotatedTypeFactory(BaseTypeChecker checker) {
+        super(checker);
+        postInit();
+    }
+
+    @Override
+    protected Set<Class<? extends Annotation>> createSupportedTypeQualifiers() {
+        return new HashSet<>(Arrays.asList(Top.class, Bottom.class));
+    }
+}

--- a/framework/src/test/java/org/checkerframework/framework/testchecker/implicitconversion/ImplicitConversionTestChecker.java
+++ b/framework/src/test/java/org/checkerframework/framework/testchecker/implicitconversion/ImplicitConversionTestChecker.java
@@ -1,0 +1,5 @@
+package org.checkerframework.framework.testchecker.implicitconversion;
+
+import org.checkerframework.common.basetype.BaseTypeChecker;
+
+public class ImplicitConversionTestChecker extends BaseTypeChecker {}

--- a/framework/src/test/java/org/checkerframework/framework/testchecker/implicitconversion/ImplicitConversionTestVisitor.java
+++ b/framework/src/test/java/org/checkerframework/framework/testchecker/implicitconversion/ImplicitConversionTestVisitor.java
@@ -1,0 +1,16 @@
+package org.checkerframework.framework.testchecker.implicitconversion;
+
+import org.checkerframework.common.basetype.BaseTypeChecker;
+import org.checkerframework.common.basetype.BaseTypeVisitor;
+
+public class ImplicitConversionTestVisitor
+        extends BaseTypeVisitor<ImplicitConversionTestAnnotatedTypeFactory> {
+    public ImplicitConversionTestVisitor(BaseTypeChecker checker) {
+        super(checker);
+    }
+
+    @Override
+    protected ImplicitConversionTestAnnotatedTypeFactory createTypeFactory() {
+        return new ImplicitConversionTestAnnotatedTypeFactory(checker);
+    }
+}

--- a/framework/src/test/java/org/checkerframework/framework/testchecker/implicitconversion/quals/Bottom.java
+++ b/framework/src/test/java/org/checkerframework/framework/testchecker/implicitconversion/quals/Bottom.java
@@ -1,0 +1,70 @@
+package org.checkerframework.framework.testchecker.implicitconversion.quals;
+
+import org.checkerframework.framework.qual.DefaultFor;
+import org.checkerframework.framework.qual.LiteralKind;
+import org.checkerframework.framework.qual.QualifierForLiterals;
+import org.checkerframework.framework.qual.SubtypeOf;
+import org.checkerframework.framework.qual.TypeKind;
+import org.checkerframework.framework.qual.TypeUseLocation;
+import org.checkerframework.framework.qual.UpperBoundFor;
+
+import java.lang.annotation.ElementType;
+import java.lang.annotation.Retention;
+import java.lang.annotation.RetentionPolicy;
+import java.lang.annotation.Target;
+
+/**
+ * Toy type system for testing impact of implicit java type conversion.
+ *
+ * @see Top
+ */
+@SubtypeOf({Top.class})
+@Retention(RetentionPolicy.RUNTIME)
+@Target({ElementType.TYPE_USE, ElementType.TYPE_PARAMETER})
+@QualifierForLiterals({LiteralKind.ALL})
+@UpperBoundFor(
+        typeKinds = {
+            TypeKind.INT,
+            TypeKind.BYTE,
+            TypeKind.SHORT,
+            TypeKind.BOOLEAN,
+            TypeKind.LONG,
+            TypeKind.CHAR,
+            TypeKind.FLOAT,
+            TypeKind.DOUBLE
+        },
+        types = {
+            String.class,
+            Double.class,
+            Boolean.class,
+            Byte.class,
+            Character.class,
+            Float.class,
+            Integer.class,
+            Long.class,
+            Short.class
+        })
+@DefaultFor(
+        value = {TypeUseLocation.LOWER_BOUND},
+        typeKinds = {
+            TypeKind.INT,
+            TypeKind.BYTE,
+            TypeKind.SHORT,
+            TypeKind.BOOLEAN,
+            TypeKind.LONG,
+            TypeKind.CHAR,
+            TypeKind.FLOAT,
+            TypeKind.DOUBLE
+        },
+        types = {
+            String.class,
+            Double.class,
+            Boolean.class,
+            Byte.class,
+            Character.class,
+            Float.class,
+            Integer.class,
+            Long.class,
+            Short.class
+        })
+public @interface Bottom {}

--- a/framework/src/test/java/org/checkerframework/framework/testchecker/implicitconversion/quals/Top.java
+++ b/framework/src/test/java/org/checkerframework/framework/testchecker/implicitconversion/quals/Top.java
@@ -1,0 +1,20 @@
+package org.checkerframework.framework.testchecker.implicitconversion.quals;
+
+import org.checkerframework.framework.qual.DefaultQualifierInHierarchy;
+import org.checkerframework.framework.qual.SubtypeOf;
+
+import java.lang.annotation.ElementType;
+import java.lang.annotation.Retention;
+import java.lang.annotation.RetentionPolicy;
+import java.lang.annotation.Target;
+
+/**
+ * Toy type system for testing impact of implicit java type conversion.
+ *
+ * @see Bottom
+ */
+@SubtypeOf({})
+@Retention(RetentionPolicy.RUNTIME)
+@Target({ElementType.TYPE_USE, ElementType.TYPE_PARAMETER})
+@DefaultQualifierInHierarchy
+public @interface Top {}

--- a/framework/tests/implicitconversion/StringConcatConversion.java
+++ b/framework/tests/implicitconversion/StringConcatConversion.java
@@ -1,0 +1,20 @@
+import org.checkerframework.framework.testchecker.implicitconversion.quals.*;
+
+import java.util.ArrayList;
+import java.util.List;
+
+public class StringConcatConversion<T> {
+
+    @Top List<? extends T> ts = new ArrayList<>();
+
+    // :: error: (type.invalid.annotations.on.use)
+    @Top String topString;
+
+    void foo(@Top T t) {
+        throwException("test normal top to bottom conversion" + ts);
+        throwException("test type variable" + t);
+        throwException("test wildcard" + ts.get(0));
+    }
+
+    void throwException(String s) {}
+}


### PR DESCRIPTION
Previously, string conversion node gets the same value as its operand has. This behavior is error prone because the annotations of its operand could be the supertypes of String's declaration bounds. This PR fixes such issue using the following rules:

1. If the operand is a type variable and has no annotations, we apply its effective annotations instead.
2. Otherwise, the operand should always have some annotations. For each annotation, if its a subtype of the string declaration bound in the same hierarchy, we add it to the result value; otherwise, we add the bound to the result value.